### PR TITLE
[codex] batched decode and benchmark gate updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,16 @@
 
 ## Benchmark impact
 <!-- paste `mlxz bench --regression` output, or N/A with justification -->
+<!-- perf PRs should also include a 3-model matrix: 3B, 8B, 14B when available -->
 
 ## Correctness
 <!-- which tests cover this; link to new tests -->
+
+## Thesis coverage
+<!-- which thesis item this change advances: TTFT, decode throughput, concurrency, memory fit, correctness -->
+
+## Rejected ideas
+<!-- if you tried an approach and dropped it, note why -->
 
 ## Rollback
 <!-- how we undo this if it regresses silently in 2 weeks -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,19 @@ docs(whitepaper): update KV-cache memory model diagram
 2. **What test proves correctness?** Link to the new or existing tests that cover the change.
 3. **What is the rollback plan?** How do we undo this if it regresses silently in two weeks?
 
+## Performance PR gate
+
+If a PR changes the engine, scheduler, cache policy, or benchmark harness, it is a performance PR.
+
+Performance PRs must include:
+
+- A baseline run on `Llama-3.1-8B-Instruct-4bit`.
+- The same change measured on at least two additional models, preferably one smaller and one larger.
+- A short note explaining whether the change is intended to improve `TTFT`, decode throughput, concurrency, or memory fit.
+- A rejected-ideas note if the optimization was attempted and discarded before landing.
+
+If the optimization only helps one model size, say that explicitly. Do not generalize it into a broad engine claim.
+
 ## Dependencies
 
 **No new dependency without justification** in the PR body. Address:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **High-throughput local inference server for Apple Silicon.**
 
-mlxz serves LLMs on your Mac with vLLM-class features — paged attention, continuous batching, prefix caching — over an OpenAI-compatible API. No CUDA, no cloud, no training. Just fast local inference.
+mlxz serves LLMs on your Mac by adapting vLLM-class serving ideas to MLX on Apple Silicon. The goal is not just to expose an API, but to improve the engine with measurable gains in TTFT, decode throughput, and concurrency over plain `mlx-lm`.
 
 ## Why mlxz?
 
@@ -36,7 +36,7 @@ Benchmarked on Apple M3 Max (128 GB) with Llama-3.1-8B-Instruct-4bit:
 | TTFT per request (cached) | **151 ms** | 561 ms | **3.7x faster** |
 | Concurrent serving | Yes (batch=8) | No | Unique to mlxz |
 
-> On agent workloads with repeated system prompts, mlxz's prefix cache eliminates redundant prefill computation. Combined with 18% faster short-generation decode, mlxz delivers significantly better overall throughput for real-world agent use cases (Claude Code, Aider, Cursor).
+> On agent workloads with repeated system prompts, mlxz's prefix cache eliminates redundant prefill computation. Combined with better short-generation performance and concurrent serving, that is the path to a genuinely useful MLX engine rather than a thin API wrapper. See [docs/whitepaper.md](docs/whitepaper.md) for the thesis.
 
 ## Quick Start
 
@@ -51,6 +51,9 @@ uv run mlxz doctor
 
 # Start serving
 uv run mlxz serve mlx-community/Llama-3.1-8B-Instruct-4bit
+
+# Apples-to-apples baseline against mlx-lm
+uv run mlxz serve mlx-community/Llama-3.1-8B-Instruct-4bit --max-concurrent-requests 1
 
 # Query (OpenAI-compatible)
 curl http://127.0.0.1:8000/v1/chat/completions \
@@ -99,7 +102,8 @@ RequestBridge (janus.Queue — async/sync thread boundary)
     v
 Engine Thread (SingleStream or ContinuousBatching)
     |-- Prefix Cache (memory + disk tiers, SHA-256 content-addressed)
-    |-- Block Manager (paged attention, refcounted, COW)
+    |-- Optional Speculative Engine (draft/target)
+    |-- Experimental paged-attention modules (not default runtime path)
     |-- Sampling (temperature, top_k, top_p, min_p, greedy)
     v
 Token Channel (janus.Queue per request — backpressure)
@@ -111,10 +115,10 @@ SSE Stream / JSON Response
 ## Features
 
 ### Prefix Caching
-Agent workloads (Claude Code, Aider, Cursor) send the same system prompt with every request. mlxz hashes prompt tokens into 256-token blocks and caches the computed KV state. On a cache hit, prefill is skipped entirely — TTFT drops from hundreds of milliseconds to tens.
+Agent workloads (Claude Code, Aider, Cursor) send the same system prompt with every request. mlxz hashes prompt tokens into small blocks by default so short shared prefixes can actually hit cache, then stores the computed KV state. On a cache hit, prefill is skipped entirely — TTFT can drop from hundreds of milliseconds to tens.
 
 ### Continuous Batching
-Multiple concurrent requests share the GPU. Each engine iteration admits new requests, processes prefill chunks, and batches decode steps. Chunked prefill prevents head-of-line blocking.
+Multiple concurrent requests share the GPU. Each engine iteration admits new requests, processes one pending prefill, and batches decode steps.
 
 ### Admission Control
 Deterministic gate that projects peak KV memory before admitting a request. Rejects with HTTP 429 + resource details when the server would OOM. Also gates on thermal state and queue depth.
@@ -158,14 +162,25 @@ uv run python benchmarks/run_benchmark.py \
   --mlxz-url http://127.0.0.1:8321 \
   --prompt-tokens 64 256 1024 \
   --max-tokens 32 128 512
+
+# Use `--max-concurrent-requests 1` on the server if you want a pure
+# single-stream comparison against mlx-lm.
+
+# Canonical agent-style workload (shared system prompt)
+uv run python benchmarks/agent_workload.py \
+  --model mlx-community/Llama-3.1-8B-Instruct-4bit \
+  --mlxz-url http://127.0.0.1:8321 \
+  --requests 10 \
+  --max-tokens 128
 ```
 
 ## Testing
 
 ```bash
-uv run pytest tests/                    # All tests (254 passing)
+uv run pytest tests/                    # All tests
 uv run pytest tests/unit/               # Unit tests only
 uv run pytest tests/integration/        # Integration tests
+uv run pytest tests/correctness/        # Correctness contract checks
 uv run pytest tests/unit/test_block_manager.py  # Hypothesis property tests
 ```
 
@@ -193,10 +208,14 @@ src/mlxz/
 | 0 | Done | Scaffold, security, observability, CI/CD |
 | 1 | Done | Single-stream engine, OpenAI API |
 | 2 | Done | Prefix cache (memory + disk) |
-| 3 | Done | Paged attention, block manager |
+| 3 | Experimental | Paged-attention modules and block manager (not default runtime path) |
 | 4 | Done | Continuous batching |
-| 5 | Done | Speculative decoding (Chen et al. rejection sampling) |
+| 5 | Done | Speculative decoding engine (runtime-selectable) |
 | 6 | Done | Circuit breaker, bench CLI, docs, hardening |
+
+## Thesis
+
+Read [docs/whitepaper.md](docs/whitepaper.md) for the explicit engine thesis: port the useful parts of vLLM's serving model to MLX, measure them honestly, and keep only the ideas that actually improve Apple Silicon inference.
 
 ## Requirements
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -15,6 +15,9 @@ Performance benchmarking suite for comparing mlxz inference against plain mlx-lm
 # 1. Start the mlxz server
 mlxz serve mlx-community/Llama-3.1-8B-Instruct-4bit --port 8321
 
+# For apples-to-apples engine comparisons, force single-stream mode:
+# mlxz serve mlx-community/Llama-3.1-8B-Instruct-4bit --port 8321 --max-concurrent-requests 1
+
 # 2. In another terminal, run the quick comparison
 python benchmarks/compare_to_mlx_lm.py \
     --model mlx-community/Llama-3.1-8B-Instruct-4bit
@@ -54,6 +57,18 @@ and mlx-lm, taking the median of N runs per configuration.
 
 Runs a single prompt through both systems and prints a side-by-side table.
 Ideal for quick sanity checks during development.
+
+### `agent_workload.py` -- Canonical Agent Scenario
+
+Runs concurrent requests that share the same system prompt (agent-style workload)
+and reports median/p95 TTFT, median decode throughput, and aggregate throughput.
+
+### Thesis matrix
+
+Performance PRs should be judged on at least three model sizes when available:
+`Llama-3.2-3B-Instruct-4bit`, `Llama-3.1-8B-Instruct-4bit`, and
+`Qwen2.5-14B-Instruct-4bit`. The point is to catch optimizations that only help
+one model size and to keep claims honest about what generalizes on MLX.
 
 ## Results Directory
 
@@ -101,6 +116,9 @@ rm benchmarks/baseline.json
 python benchmarks/run_benchmark.py --model <your-model>
 ```
 
+By default, `run_benchmark.py` exits non-zero when regressions exceed 10%.
+Use `--no-fail-on-regression` to report regressions without failing.
+
 ## Interpreting Results
 
 ### What matters most
@@ -108,6 +126,11 @@ python benchmarks/run_benchmark.py --model <your-model>
 1. **Decode tok/s** is the primary throughput metric.  Higher is better.
    mlxz targets parity or improvement over plain mlx-lm through KV-cache
    quantisation, prefix caching, and continuous batching.
+
+   When comparing the pure engine path against mlx-lm, start mlxz with
+   `--max-concurrent-requests 1` so the result excludes continuous batching
+   overhead. Compare the concurrent-serving mode separately, because that is
+   the feature mlx-lm does not have at all.
 
 2. **TTFT** matters for interactive use.  mlxz adds HTTP overhead but may
    offset it with prefix cache hits on repeated prompts.

--- a/benchmarks/agent_workload.py
+++ b/benchmarks/agent_workload.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Canonical agent-style benchmark with repeated shared system prompt."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import time
+
+import httpx
+
+
+SYSTEM_PROMPT = (
+    "You are a precise coding assistant. Keep answers concise, factual, and actionable. "
+    "When uncertain, state assumptions explicitly."
+)
+
+
+async def _run_one(
+    client: httpx.AsyncClient,
+    url: str,
+    model: str,
+    user_prompt: str,
+    max_tokens: int,
+) -> dict:
+    t0 = time.perf_counter()
+    first_token_time: float | None = None
+    completion_tokens = 0
+    completion_tokens_from_usage = 0
+
+    async with client.stream(
+        "POST",
+        f"{url}/v1/chat/completions",
+        json={
+            "model": model,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            "max_tokens": max_tokens,
+            "stream": True,
+            "temperature": 0,
+            "seed": 42,
+        },
+    ) as resp:
+        resp.raise_for_status()
+        async for line in resp.aiter_lines():
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:]
+            if payload == "[DONE]":
+                break
+            chunk = json.loads(payload)
+            if chunk["choices"][0].get("delta", {}).get("content"):
+                if first_token_time is None:
+                    first_token_time = time.perf_counter()
+                completion_tokens += 1
+            if chunk.get("usage"):
+                completion_tokens_from_usage = chunk["usage"].get(
+                    "completion_tokens", completion_tokens_from_usage
+                )
+
+    total = time.perf_counter() - t0
+    ttft = (first_token_time - t0) if first_token_time else total
+    decode = total - ttft
+    total_completion_tokens = completion_tokens_from_usage or completion_tokens
+    return {
+        "ttft_ms": ttft * 1000.0,
+        "decode_tps": total_completion_tokens / decode if decode > 0 else 0.0,
+        "total_ms": total * 1000.0,
+        "completion_tokens": total_completion_tokens,
+    }
+
+
+async def main_async(args) -> None:
+    prompts = [
+        "Explain the difference between a mutex and semaphore.",
+        "Write a Python function for topological sort.",
+        "Summarize HTTP caching headers for APIs.",
+        "List common causes of flaky CI tests.",
+        "Show a safe SQL parameterization example in Python.",
+        "Explain why backpressure matters in streaming APIs.",
+        "Describe optimistic vs pessimistic locking.",
+        "Give a concise incident response checklist.",
+    ]
+    async with httpx.AsyncClient(timeout=180) as client:
+        tasks = [
+            _run_one(
+                client,
+                args.mlxz_url,
+                args.model,
+                prompts[i % len(prompts)],
+                args.max_tokens,
+            )
+            for i in range(args.requests)
+        ]
+        started = time.perf_counter()
+        results = await asyncio.gather(*tasks)
+        wall = time.perf_counter() - started
+
+    ttfts = [r["ttft_ms"] for r in results]
+    tps = [r["decode_tps"] for r in results]
+    total_tokens = sum(r["completion_tokens"] for r in results)
+
+    print("\nAgent workload summary")
+    print(f"requests: {args.requests}")
+    print(f"shared system prompt tokens: reused across all requests")
+    print(f"median TTFT: {statistics.median(ttfts):.1f} ms")
+    print(f"p95 TTFT: {sorted(ttfts)[int(len(ttfts) * 0.95) - 1]:.1f} ms")
+    print(f"median decode throughput: {statistics.median(tps):.2f} tok/s")
+    print(f"aggregate throughput: {total_tokens / wall:.2f} tok/s")
+    print(f"wall time: {wall:.2f} s")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run canonical agent-style workload benchmark")
+    parser.add_argument("--mlxz-url", default="http://127.0.0.1:8321")
+    parser.add_argument("--model", default="mlx-community/Llama-3.1-8B-Instruct-4bit")
+    parser.add_argument("--requests", type=int, default=10)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    args = parser.parse_args()
+    asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/compare_to_mlx_lm.py
+++ b/benchmarks/compare_to_mlx_lm.py
@@ -40,7 +40,8 @@ def run_mlxz(url: str, model: str, prompt: str, max_tokens: int) -> dict:
     """Run a single streaming request against mlxz and return timing data."""
     t0 = time.perf_counter()
     first_token_time: float | None = None
-    tokens: list[str] = []
+    chunks: list[str] = []
+    completion_tokens_from_usage = 0
 
     with httpx.Client(timeout=120) as client:
         with client.stream(
@@ -51,6 +52,8 @@ def run_mlxz(url: str, model: str, prompt: str, max_tokens: int) -> dict:
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": max_tokens,
                 "stream": True,
+                "temperature": 0,
+                "seed": 42,
             },
             headers={"Content-Type": "application/json"},
         ) as resp:
@@ -66,12 +69,16 @@ def run_mlxz(url: str, model: str, prompt: str, max_tokens: int) -> dict:
                 if content:
                     if first_token_time is None:
                         first_token_time = time.perf_counter()
-                    tokens.append(content)
+                    chunks.append(content)
+                if chunk.get("usage"):
+                    completion_tokens_from_usage = chunk["usage"].get(
+                        "completion_tokens", completion_tokens_from_usage
+                    )
 
     total = time.perf_counter() - t0
     ttft = (first_token_time - t0) if first_token_time else total
     decode_time = total - ttft
-    n_tokens = len(tokens)
+    n_tokens = completion_tokens_from_usage or len(chunks)
 
     return {
         "system": "mlxz",
@@ -79,7 +86,7 @@ def run_mlxz(url: str, model: str, prompt: str, max_tokens: int) -> dict:
         "ttft_ms": round(ttft * 1000, 1),
         "decode_tps": round(n_tokens / decode_time, 1) if decode_time > 0 else 0,
         "total_ms": round(total * 1000, 1),
-        "output": "".join(tokens),
+        "output": "".join(chunks),
     }
 
 
@@ -92,18 +99,27 @@ def run_mlx_lm(model_path: str, prompt: str, max_tokens: int) -> dict:
     mlx_lm.generate(model, tokenizer, prompt="Hi", max_tokens=1, verbose=False)
 
     t0 = time.perf_counter()
-    output = mlx_lm.generate(
-        model, tokenizer, prompt=prompt, max_tokens=max_tokens, verbose=False
-    )
+    first_token_time: float | None = None
+    parts: list[str] = []
+    n_tokens = 0
+    for step in mlx_lm.stream_generate(
+        model, tokenizer, prompt=prompt, max_tokens=max_tokens
+    ):
+        if step.text:
+            if first_token_time is None:
+                first_token_time = time.perf_counter()
+            parts.append(step.text)
+            n_tokens += 1
+    output = "".join(parts)
     total = time.perf_counter() - t0
-
-    n_tokens = len(tokenizer.encode(output))
+    ttft = (first_token_time - t0) if first_token_time else total
+    decode_time = total - ttft
 
     return {
         "system": "mlx-lm",
         "tokens": n_tokens,
-        "ttft_ms": round(total * 1000 / max(n_tokens, 1), 1),
-        "decode_tps": round(n_tokens / total, 1) if total > 0 else 0,
+        "ttft_ms": round(ttft * 1000, 1),
+        "decode_tps": round(n_tokens / decode_time, 1) if decode_time > 0 else 0,
         "total_ms": round(total * 1000, 1),
         "output": output,
     }

--- a/benchmarks/profile_decode.py
+++ b/benchmarks/profile_decode.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Profile decode-path cost split for MLX models.
+
+The script measures where decode time goes on a greedy decode workload:
+- total model forward time
+- cache.update_and_fetch time
+- scaled dot-product attention time
+- sampler / token selection time
+
+This is meant to answer whether the remaining throughput gap is in cache
+mutation, attention, or the Python loop around the model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import time
+from collections import defaultdict
+from typing import Any
+
+import mlx.core as mx
+import mlx_lm
+
+
+DEFAULT_PROMPT = (
+    "Explain the difference between a mutex and a semaphore in practical terms."
+)
+
+
+@dataclasses.dataclass
+class Timings:
+    total_forward_ms: float = 0.0
+    cache_update_ms: float = 0.0
+    attention_ms: float = 0.0
+    sampler_ms: float = 0.0
+    decode_steps: int = 0
+    prefill_ms: float = 0.0
+
+    def add(self, other: "Timings") -> None:
+        self.total_forward_ms += other.total_forward_ms
+        self.cache_update_ms += other.cache_update_ms
+        self.attention_ms += other.attention_ms
+        self.sampler_ms += other.sampler_ms
+        self.decode_steps += other.decode_steps
+        self.prefill_ms += other.prefill_ms
+
+
+def _wrap_method(obj: Any, method_name: str, recorder) -> None:
+    original = getattr(obj, method_name)
+
+    def wrapped(*args, **kwargs):
+        t0 = time.perf_counter()
+        result = original(*args, **kwargs)
+        mx.eval(result)
+        recorder((time.perf_counter() - t0) * 1000.0)
+        return result
+
+    setattr(obj, method_name, wrapped)
+
+
+def profile_model(
+    model_path: str,
+    prompt: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    model, tokenizer = mlx_lm.load(model_path)
+    prompt_ids = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        tokenize=True,
+        add_generation_prompt=True,
+    )
+    if isinstance(prompt_ids, dict):
+        prompt_ids = prompt_ids["input_ids"]
+    elif hasattr(prompt_ids, "input_ids"):
+        prompt_ids = prompt_ids.input_ids
+    else:
+        prompt_ids = list(prompt_ids)
+
+    # Monkeypatch the Llama-specific SDPA call so we can time it.
+    import mlx_lm.models.base as base_mod
+    from mlx_lm.models import cache as cache_mod
+    import mlx_lm.models.llama as llama_mod
+
+    timings = Timings()
+    phase_timings: dict[str, Timings] = defaultdict(Timings)
+    phase = {"name": "prefill"}
+
+    original_sdpa_base = base_mod.scaled_dot_product_attention
+    original_sdpa_llama = llama_mod.scaled_dot_product_attention
+    decoded: list[int] = []
+
+    def timed_sdpa(*args, **kwargs):
+        t0 = time.perf_counter()
+        out = original_sdpa_base(*args, **kwargs)
+        mx.eval(out)
+        delta = (time.perf_counter() - t0) * 1000.0
+        timings.attention_ms += delta
+        phase_timings[phase["name"]].attention_ms += delta
+        return out
+
+    base_mod.scaled_dot_product_attention = timed_sdpa
+    llama_mod.scaled_dot_product_attention = timed_sdpa
+
+    try:
+        cache = cache_mod.make_prompt_cache(model)
+        for layer_cache in cache:
+            _wrap_method(
+                layer_cache,
+                "update_and_fetch",
+                lambda delta: (
+                    setattr(
+                        timings,
+                        "cache_update_ms",
+                        timings.cache_update_ms + delta,
+                    ),
+                    setattr(
+                        phase_timings[phase["name"]],
+                        "cache_update_ms",
+                        phase_timings[phase["name"]].cache_update_ms + delta,
+                    ),
+                ),
+            )
+
+        # Prefill
+        t0 = time.perf_counter()
+        logits = model(mx.array([prompt_ids]), cache=cache)
+        mx.eval(logits)
+        timings.prefill_ms = (time.perf_counter() - t0) * 1000.0
+
+        # Decode steps
+        token_id = mx.argmax(logits[:, -1, :], axis=-1).item()
+        decoded = [token_id]
+        for _ in range(max_tokens - 1):
+            phase["name"] = "decode"
+            t0 = time.perf_counter()
+            logits = model(mx.array([[token_id]]), cache=cache)
+            mx.eval(logits)
+            forward_ms = (time.perf_counter() - t0) * 1000.0
+            timings.total_forward_ms += forward_ms
+            phase_timings["decode"].total_forward_ms += forward_ms
+            timings.decode_steps += 1
+            phase_timings["decode"].decode_steps += 1
+
+            t1 = time.perf_counter()
+            token_id = mx.argmax(logits[:, -1, :], axis=-1).item()
+            sampler_ms = (time.perf_counter() - t1) * 1000.0
+            timings.sampler_ms += sampler_ms
+            phase_timings["decode"].sampler_ms += sampler_ms
+            decoded.append(token_id)
+            if token_id == getattr(tokenizer, "eos_token_id", None):
+                break
+    finally:
+        base_mod.scaled_dot_product_attention = original_sdpa_base
+        llama_mod.scaled_dot_product_attention = original_sdpa_llama
+
+    return {
+        "model": model_path,
+        "prompt_tokens": len(prompt_ids),
+        "generated_tokens": len(decoded),
+        "prefill_ms": round(timings.prefill_ms, 2),
+        "decode_forward_ms": round(timings.total_forward_ms, 2),
+        "cache_update_ms": round(timings.cache_update_ms, 2),
+        "attention_ms": round(timings.attention_ms, 2),
+        "sampler_ms": round(timings.sampler_ms, 2),
+        "decode_steps": timings.decode_steps,
+        "per_token": {
+            "forward_ms": round(timings.total_forward_ms / max(timings.decode_steps, 1), 3),
+            "cache_update_ms": round(timings.cache_update_ms / max(timings.decode_steps, 1), 3),
+            "attention_ms": round(timings.attention_ms / max(timings.decode_steps, 1), 3),
+            "sampler_ms": round(timings.sampler_ms / max(timings.decode_steps, 1), 3),
+        },
+        "phase_breakdown": {
+            k: {
+                "forward_ms": round(v.total_forward_ms, 2),
+                "cache_update_ms": round(v.cache_update_ms, 2),
+                "attention_ms": round(v.attention_ms, 2),
+                "sampler_ms": round(v.sampler_ms, 2),
+                "decode_steps": v.decode_steps,
+            }
+            for k, v in phase_timings.items()
+        },
+        "decoded": decoded,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Profile MLX decode-path cost split")
+    parser.add_argument("--model", default="mlx-community/Llama-3.1-8B-Instruct-4bit")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
+    parser.add_argument("--max-tokens", type=int, default=128)
+    args = parser.parse_args()
+
+    result = profile_model(args.model, args.prompt, args.max_tokens)
+    print("\nDecode profile")
+    print(f"model: {result['model']}")
+    print(f"prompt_tokens: {result['prompt_tokens']}")
+    print(f"generated_tokens: {result['generated_tokens']}")
+    print(f"prefill_ms: {result['prefill_ms']}")
+    print(f"decode_forward_ms: {result['decode_forward_ms']}")
+    print(f"cache_update_ms: {result['cache_update_ms']}")
+    print(f"attention_ms: {result['attention_ms']}")
+    print(f"sampler_ms: {result['sampler_ms']}")
+    print(f"per_token: {result['per_token']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/benchmark_20260418_134706.json
+++ b/benchmarks/results/benchmark_20260418_134706.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 32,
+    "completion_tokens": 32,
+    "ttft_ms": 133.66,
+    "decode_tps": 7.15,
+    "total_latency_ms": 4609.01,
+    "timestamp": "2026-04-18T13:46:22.778847"
+  },
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 232.03,
+    "decode_tps": 6.28,
+    "total_latency_ms": 20610.11,
+    "timestamp": "2026-04-18T13:46:45.395342"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_134903.json
+++ b/benchmarks/results/benchmark_20260418_134903.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 32,
+    "completion_tokens": 32,
+    "ttft_ms": 68.77,
+    "decode_tps": 17.94,
+    "total_latency_ms": 1852.5,
+    "timestamp": "2026-04-18T13:48:46.507403"
+  },
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 67.63,
+    "decode_tps": 17.68,
+    "total_latency_ms": 7305.85,
+    "timestamp": "2026-04-18T13:49:03.649968"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_135040.json
+++ b/benchmarks/results/benchmark_20260418_135040.json
@@ -1,0 +1,46 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 32,
+    "completion_tokens": 32,
+    "ttft_ms": 33.75,
+    "decode_tps": 59.73,
+    "total_latency_ms": 569.53,
+    "timestamp": "2026-04-18T13:50:23.349043"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 32,
+    "completion_tokens": 32,
+    "ttft_ms": 253.41,
+    "decode_tps": 59.2,
+    "total_latency_ms": 793.96,
+    "timestamp": "2026-04-18T13:50:26.619452"
+  },
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 27.07,
+    "decode_tps": 54.62,
+    "total_latency_ms": 2370.64,
+    "timestamp": "2026-04-18T13:50:35.664925"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 248.63,
+    "decode_tps": 59.47,
+    "total_latency_ms": 2384.17,
+    "timestamp": "2026-04-18T13:50:40.502695"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_140830.json
+++ b/benchmarks/results/benchmark_20260418_140830.json
@@ -1,0 +1,46 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 32,
+    "completion_tokens": 32,
+    "ttft_ms": 28.13,
+    "decode_tps": 71.31,
+    "total_latency_ms": 476.87,
+    "timestamp": "2026-04-18T14:08:20.238723"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 32,
+    "completion_tokens": 32,
+    "ttft_ms": 137.99,
+    "decode_tps": 77.29,
+    "total_latency_ms": 552.01,
+    "timestamp": "2026-04-18T14:08:22.251181"
+  },
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 54.77,
+    "decode_tps": 69.52,
+    "total_latency_ms": 1896.08,
+    "timestamp": "2026-04-18T14:08:24.701894"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 174.39,
+    "decode_tps": 76.25,
+    "total_latency_ms": 1839.9,
+    "timestamp": "2026-04-18T14:08:28.416732"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_180504.json
+++ b/benchmarks/results/benchmark_20260418_180504.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 28.69,
+    "decode_tps": 68.46,
+    "total_latency_ms": 1898.27,
+    "timestamp": "2026-04-18T18:04:57.446700"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.53,
+    "decode_tps": 76.82,
+    "total_latency_ms": 1790.82,
+    "timestamp": "2026-04-18T18:05:04.507347"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_180641.json
+++ b/benchmarks/results/benchmark_20260418_180641.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 272.74,
+    "decode_tps": 70.78,
+    "total_latency_ms": 2081.28,
+    "timestamp": "2026-04-18T18:06:28.830669"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 138.6,
+    "decode_tps": 75.97,
+    "total_latency_ms": 1810.42,
+    "timestamp": "2026-04-18T18:06:39.974365"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_181056.json
+++ b/benchmarks/results/benchmark_20260418_181056.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 129,
+    "ttft_ms": 258.69,
+    "decode_tps": 41.24,
+    "total_latency_ms": 3386.9,
+    "timestamp": "2026-04-18T18:10:41.614865"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 166.98,
+    "decode_tps": 52.35,
+    "total_latency_ms": 2592.8,
+    "timestamp": "2026-04-18T18:10:54.317776"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_192611.json
+++ b/benchmarks/results/benchmark_20260418_192611.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 271.13,
+    "decode_tps": 73.2,
+    "total_latency_ms": 2019.72,
+    "timestamp": "2026-04-18T19:26:01.035736"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.57,
+    "decode_tps": 76.93,
+    "total_latency_ms": 1788.44,
+    "timestamp": "2026-04-18T19:26:09.837001"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_193124.json
+++ b/benchmarks/results/benchmark_20260418_193124.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 0,
+    "max_tokens": 128,
+    "completion_tokens": 1,
+    "ttft_ms": 289.8,
+    "decode_tps": 6.97,
+    "total_latency_ms": 433.27,
+    "timestamp": "2026-04-18T19:30:10.047360"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.41,
+    "decode_tps": 77.23,
+    "total_latency_ms": 1781.94,
+    "timestamp": "2026-04-18T19:31:22.592483"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_193216.json
+++ b/benchmarks/results/benchmark_20260418_193216.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 38.1,
+    "decode_tps": 75.95,
+    "total_latency_ms": 1723.34,
+    "timestamp": "2026-04-18T19:32:07.486972"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.77,
+    "decode_tps": 77.05,
+    "total_latency_ms": 1786.11,
+    "timestamp": "2026-04-18T19:32:14.262078"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_194002.json
+++ b/benchmarks/results/benchmark_20260418_194002.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 38.64,
+    "decode_tps": 75.97,
+    "total_latency_ms": 1723.57,
+    "timestamp": "2026-04-18T19:39:54.010102"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.78,
+    "decode_tps": 77.21,
+    "total_latency_ms": 1782.6,
+    "timestamp": "2026-04-18T19:40:02.567618"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_195110.json
+++ b/benchmarks/results/benchmark_20260418_195110.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 38.23,
+    "decode_tps": 75.97,
+    "total_latency_ms": 1723.14,
+    "timestamp": "2026-04-18T19:51:01.292195"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.35,
+    "decode_tps": 77.12,
+    "total_latency_ms": 1784.2,
+    "timestamp": "2026-04-18T19:51:09.177346"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_202617.json
+++ b/benchmarks/results/benchmark_20260418_202617.json
@@ -1,0 +1,13 @@
+[
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.89,
+    "decode_tps": 76.69,
+    "total_latency_ms": 1793.86,
+    "timestamp": "2026-04-18T20:26:17.749012"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_202643.json
+++ b/benchmarks/results/benchmark_20260418_202643.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 49.08,
+    "decode_tps": 76.42,
+    "total_latency_ms": 1723.94,
+    "timestamp": "2026-04-18T20:26:35.175619"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.51,
+    "decode_tps": 77.06,
+    "total_latency_ms": 1785.63,
+    "timestamp": "2026-04-18T20:26:42.117892"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_203405.json
+++ b/benchmarks/results/benchmark_20260418_203405.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 287.38,
+    "decode_tps": 76.56,
+    "total_latency_ms": 1959.35,
+    "timestamp": "2026-04-18T20:33:55.289506"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.08,
+    "decode_tps": 77.09,
+    "total_latency_ms": 1784.52,
+    "timestamp": "2026-04-18T20:34:03.860742"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_203610.json
+++ b/benchmarks/results/benchmark_20260418_203610.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 45.28,
+    "decode_tps": 76.49,
+    "total_latency_ms": 1718.71,
+    "timestamp": "2026-04-18T20:36:03.964907"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.32,
+    "decode_tps": 77.02,
+    "total_latency_ms": 1786.28,
+    "timestamp": "2026-04-18T20:36:09.036655"
+  }
+]

--- a/benchmarks/results/benchmark_20260418_203735.json
+++ b/benchmarks/results/benchmark_20260418_203735.json
@@ -1,0 +1,24 @@
+[
+  {
+    "system": "mlxz",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 128,
+    "ttft_ms": 44.47,
+    "decode_tps": 76.51,
+    "total_latency_ms": 1717.39,
+    "timestamp": "2026-04-18T20:37:28.337864"
+  },
+  {
+    "system": "mlx-lm",
+    "model": "mlx-community/Llama-3.1-8B-Instruct-4bit",
+    "prompt_tokens": 107,
+    "max_tokens": 128,
+    "completion_tokens": 127,
+    "ttft_ms": 137.11,
+    "decode_tps": 77.18,
+    "total_latency_ms": 1782.62,
+    "timestamp": "2026-04-18T20:37:33.447859"
+  }
+]

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -99,7 +99,8 @@ def benchmark_mlxz(
     """Benchmark mlxz via streaming HTTP to get accurate TTFT."""
     t0 = time.perf_counter()
     first_token_time: float | None = None
-    total_tokens = 0
+    content_chunks = 0
+    completion_tokens_from_usage = 0
     prompt_token_count = 0
 
     with httpx.Client(timeout=120) as client:
@@ -111,6 +112,8 @@ def benchmark_mlxz(
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": max_tokens,
                 "stream": True,
+                "temperature": 0,
+                "seed": 42,
             },
             headers={"Content-Type": "application/json"},
         ) as resp:
@@ -126,14 +129,18 @@ def benchmark_mlxz(
                 if delta.get("content"):
                     if first_token_time is None:
                         first_token_time = time.perf_counter()
-                    total_tokens += 1
+                    content_chunks += 1
                 # Usage may appear in the final chunk
                 if chunk.get("usage"):
                     prompt_token_count = chunk["usage"].get(
                         "prompt_tokens", prompt_token_count
                     )
+                    completion_tokens_from_usage = chunk["usage"].get(
+                        "completion_tokens", completion_tokens_from_usage
+                    )
 
     total_time = time.perf_counter() - t0
+    total_tokens = completion_tokens_from_usage or content_chunks
     ttft = (
         (first_token_time - t0) * 1000
         if first_token_time is not None
@@ -196,17 +203,28 @@ def benchmark_mlx_lm(
         prompt_ids = list(template_result)
 
     t0 = time.perf_counter()
-    output = mlx_lm.generate(
+    first_token_time: float | None = None
+    output_parts: list[str] = []
+    output_tokens = 0
+    for step in mlx_lm.stream_generate(
         model,
         tokenizer,
         prompt=prompt,
         max_tokens=max_tokens,
-        verbose=False,
-    )
+    ):
+        if step.text:
+            if first_token_time is None:
+                first_token_time = time.perf_counter()
+            output_parts.append(step.text)
+            output_tokens += 1
     total_time = time.perf_counter() - t0
-
-    output_tokens = len(tokenizer.encode(output))
-    decode_tps = output_tokens / total_time if total_time > 0 else 0.0
+    ttft_ms = (
+        (first_token_time - t0) * 1000
+        if first_token_time is not None
+        else total_time * 1000
+    )
+    decode_time = total_time - (ttft_ms / 1000)
+    decode_tps = output_tokens / decode_time if decode_time > 0 else 0.0
 
     return BenchmarkResult(
         system="mlx-lm",
@@ -214,8 +232,7 @@ def benchmark_mlx_lm(
         prompt_tokens=len(prompt_ids),
         max_tokens=max_tokens,
         completion_tokens=output_tokens,
-        # mlx_lm.generate doesn't expose TTFT; approximate as latency / tokens
-        ttft_ms=round(total_time * 1000 / max(output_tokens, 1), 2),
+        ttft_ms=round(ttft_ms, 2),
         decode_tps=round(decode_tps, 2),
         total_latency_ms=round(total_time * 1000, 2),
         timestamp=datetime.now().isoformat(),
@@ -333,6 +350,12 @@ def main() -> None:
         help="Runs per configuration; median is kept (default: %(default)s)",
     )
     parser.add_argument(
+        "--fail-on-regression",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Exit non-zero when baseline regressions are detected (default: true)",
+    )
+    parser.add_argument(
         "--skip-mlx-lm",
         action="store_true",
         help="Skip mlx-lm direct benchmarks (mlxz-only mode)",
@@ -426,12 +449,15 @@ def main() -> None:
         print(f"Baseline saved to {baseline_file}")
     else:
         # Compare against baseline
-        _compare_baseline(baseline_file, all_results)
+        regressions = _compare_baseline(baseline_file, all_results)
+        if regressions > 0 and args.fail_on_regression:
+            print("\nFailing due to benchmark regressions.")
+            sys.exit(1)
 
 
 def _compare_baseline(
     baseline_path: Path, current: list[BenchmarkResult]
-) -> None:
+) -> int:
     """Compare current results against a saved baseline and flag regressions."""
     with open(baseline_path) as f:
         baseline_data = json.load(f)
@@ -443,6 +469,7 @@ def _compare_baseline(
             r
             for r in current
             if r.system == br["system"]
+            and r.model == br["model"]
             and r.prompt_tokens == br["prompt_tokens"]
             and r.max_tokens == br["max_tokens"]
         ]
@@ -466,6 +493,7 @@ def _compare_baseline(
         print(f"\n  WARNING: {regressions} regression(s) detected (>10% slower)")
     else:
         print("\n  All results within 10% of baseline.")
+    return regressions
 
 
 if __name__ == "__main__":

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,12 +9,12 @@ mlxz is a serving engine, not a training framework. It loads models via mlx-lm a
 ### Engine Layer
 - **SingleStreamEngine** — Batch=1, synchronous. Simple and fast for single-user.
 - **ContinuousBatchingEngine** — Iteration-level batching for concurrent requests.
-- **SpeculativeEngine** — Draft-target with rejection sampling for higher throughput.
+- **SpeculativeEngine** — Runtime-selectable draft-target engine with rejection sampling.
 
 ### Cache Layer
 - **PrefixCacheMemory** — In-memory LRU with content-addressed hashing
 - **PrefixCacheDisk** — Persistent cache with safetensors + SHA-256 checksums
-- **BlockManager** — Paged KV cache with reference counting and COW
+- **BlockManager / PagedKVCache** — Experimental paged-attention primitives
 
 ### API Layer
 - **FastAPI** — OpenAI-compatible endpoints with SSE streaming

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,6 +1,12 @@
 # Performance Experiments Log
 
+This log exists to keep the project honest about the original thesis: port serving ideas from vLLM to MLX, measure them on real workloads, and keep the ones that actually improve the engine.
+
 ## Baseline Performance (M3 Max 128GB, Llama-3.1-8B-Instruct-4bit)
+
+Bench harness notes:
+- Benchmarks run with `temperature=0` and fixed seed for deterministic decode.
+- `mlx-lm` TTFT is measured via `mlx_lm.stream_generate()` first-token timing.
 
 | Config | mlxz | mlx-lm | Delta |
 |--------|------|--------|-------|
@@ -12,6 +18,34 @@
 | TTFT (prefix cached) | 151 ms | 561 ms | **3.7x faster** |
 
 **Analysis:** mlxz wins on short generations and agent workloads (prefix cache). mlx-lm wins on long isolated generations because it uses `mx.async_eval()` to overlap GPU compute with Python sampling.
+
+**Comparison rule:** For apples-to-apples engine comparisons, run mlxz in single-stream mode with `--max-concurrent-requests 1`. Measure continuous batching separately, because concurrency is a product feature, not part of the pure single-request baseline.
+
+**Current concurrent-serving checkpoint:** On an 8-request agent-style workload in continuous mode, the server held a median TTFT of 820.5 ms and aggregate throughput of 64.62 tok/s. That is not a raw decode win, but it is a real multi-request serving result that `mlx-lm` does not provide.
+
+**Current repeated-prefix checkpoint:** After storing chunk-boundary prefix states instead of only full prompts, the sequential agent-style workload on the 8B model improved to a median TTFT of 71.4 ms, compared with 104.1 ms for `mlx-lm`. Decode throughput is still slightly behind (`71.86 tok/s` vs `76.97 tok/s`), so the engine is not a blanket throughput win yet, but the prefix-cache story is now real instead of theoretical.
+
+## What Still Needs To Happen
+
+- Compile or shape-bucket the stable hot paths only if they survive a multi-model test matrix.
+- Keep testing on at least two additional models, not just the 8B headline model.
+- Measure the workloads that matter to the thesis: short generation, long generation, repeated-prefix agent traffic, and moderate concurrency.
+- Only keep an optimization if it survives both correctness checks and multi-model benchmarks.
+
+## Rejected / Archived Ideas
+
+When an optimization fails, it belongs here. Keep the record short and factual:
+
+- What was tried
+- Which model(s) and workload(s) were used
+- What broke or failed to improve
+- Why we rejected it
+
+Current entry:
+
+- `mx.async_eval()` prefetch in the shared engine/cache path: crashed on generations over 64 tokens because cache state became inconsistent across streams.
+- `mx.compile()` on the decode step: safe, but only a small win. On the current matrix it improved 8B by about 1.6%, 3B by about 0.3%, and 14B by about 1.4%. Not enough to close the mlx-lm gap by itself.
+- Speculative decoding with a 3B draft model on the 8B target: started after wiring `set_prefix_cache()` into the engine, but the current implementation was slower than plain single-stream decoding and worse than `mlx-lm` on the same benchmark. Keep it out of the default path until the draft-target cache reuse story is stronger.
 
 ---
 
@@ -63,6 +97,13 @@ def _compiled_decode_step(model, token_id, cache):
 
 **Risk:** `mx.compile()` may not support models with dynamic shapes or KV cache mutations. Need to test.
 
+**Measured result:** The compiled decode step is valid, but the end-to-end gain was small:
+- 8B: ~1.6% faster than the plain decode loop
+- 3B: ~0.3% faster
+- 14B: ~1.4% faster
+
+**Status:** NOT ENOUGH TO SHIP as a primary optimization.
+
 ---
 
 ## Experiment 4: Prompt Compilation Cache (Planned)
@@ -78,6 +119,83 @@ def _compiled_decode_step(model, token_id, cache):
 **Hypothesis:** `tokenizer.decode([token_id])` is called per-token. Batching decode calls (accumulating token IDs and decoding every N tokens) could reduce tokenizer overhead.
 
 **Approach:** Accumulate 8-16 token IDs, batch decode, split into per-token strings for SSE delivery.
+
+## Experiment 6: Multi-Model Benchmark Matrix
+
+**Hypothesis:** An optimization that only helps one model size is probably not a general engine improvement. The right bar is stable or improved results on at least one smaller model and one larger model, compared with plain `mlx-lm`.
+
+**Approach:** Run the same benchmark matrix on `Llama-3.2-3B-Instruct-4bit`, `Llama-3.1-8B-Instruct-4bit`, and `Qwen2.5-14B-Instruct-4bit` with deterministic sampling and the canonical agent workload.
+
+**Status:** Planned. This should become part of the merge gate for performance work.
+
+## Experiment 7: Speculative Decoding (Draft-Target)
+
+**Hypothesis:** A smaller draft model should let the target model verify multiple candidate tokens per pass and reduce end-to-end latency.
+
+**Setup:** 8B target model + 3B draft model, `num_draft_tokens=4`.
+
+**Measured result:** The current implementation did not outperform the single-stream baseline. On the 8B benchmark prompt, speculative mode was slower than plain `mlxz` and also slower than `mlx-lm`.
+
+**Status:** NOT A DEFAULT OPTIMIZATION. The engine now accepts the shared prefix-cache wiring used at startup, but the draft-target cache reuse path still needs real work before this becomes competitive.
+
+---
+
+## Experiment 8: Greedy Decode Chunking + Continuous Starvation Fix
+
+**Hypothesis:** The remaining single-request decode gap is mostly Python boundary overhead, and the concurrent agent workload should not be allowed to enter the single-request fast path while other requests are already resident.
+
+**Changes:**
+- Compiled greedy decode now emits fixed-size chunks instead of one token per call in the single-request path.
+- Continuous mode only uses the single-request fast path when it is actually serving one request total.
+
+**Measured result on `Llama-3.1-8B-Instruct-4bit`:**
+- Single-request benchmark: `mlxz` 76.0 tok/s vs `mlx-lm` 77.0 tok/s, with TTFT dropping to 38.1 ms from 137.8 ms.
+- Agent workload, 8 concurrent requests: median TTFT 541.0 ms, p95 TTFT 879.7 ms, median decode throughput 8.90 tok/s, aggregate throughput 68.35 tok/s.
+- Removing redundant state evals around compiled decode calls did not materially change throughput; the run stayed at single-request parity and the concurrent workload remained in the same band.
+- Increasing SSE delivery batching and trimming hot-path attribute lookups did not materially move throughput either; the agent workload stayed in the same 67-68 tok/s band.
+
+**Status:** SHIPPED FOR NOW. The decode sweep improved latency materially and preserved throughput parity on the isolated path, but it did not produce a clear aggregate-throughput win over the concurrent baseline.
+
+---
+
+## Experiment 9: Greedy Chunk Size Sweep
+
+**Hypothesis:** Increasing the fixed greedy decode chunk size would amortize more Python/model-call overhead in the single-request path without affecting the concurrent path.
+
+**Change:** Increased the compiled greedy chunk from 8 to 16 tokens in the single-request decode fast path.
+
+**Measured result:** No material throughput gain.
+- Single-request benchmark remained in the same band as the prior run: `mlxz` 76.4 tok/s vs `mlx-lm` 77.1 tok/s.
+- Agent workload, 8 concurrent requests: aggregate throughput 67.57 tok/s, median TTFT 599.9 ms.
+
+**Status:** NOT A MATERIAL WIN. Keep the larger chunk size only if later runs show it is still neutral; otherwise revert it during the next cleanup pass.
+
+---
+
+## Experiment 10: Cache-Class Swap (`KVCache` vs `RotatingKVCache`)
+
+**Hypothesis:** Using `RotatingKVCache` instead of the default append-style cache might reduce decode-side cache overhead enough to matter on larger models.
+
+**Measured result:** No meaningful decode improvement.
+- 8B: `KVCache` 73.08 tok/s vs `RotatingKVCache256` 73.15 tok/s.
+- 3B: `KVCache` 140.62 tok/s vs `RotatingKVCache256` 141.64 tok/s.
+- 14B: `KVCache` 39.59 tok/s vs `RotatingKVCache256` 39.53 tok/s.
+
+**Status:** REJECTED. The cache implementation swap does not solve the decode bottleneck; the main work still needs to happen in MLX primitives or a true multi-request batching strategy.
+
+---
+
+## Experiment 11: Exact-Offset Batched Decode
+
+**Hypothesis:** Requests that are already at the same cache offset can share one forward pass, letting the engine amortize cache update and attention work across compatible requests without changing sampling semantics.
+
+**Change:** Group decode requests by current cache offset, batch their caches into one MLX call, then scatter the updated cache state back to each request.
+
+**Measured result on `Llama-3.1-8B-Instruct-4bit`:**
+- Single-request benchmark stayed in the same band: `mlxz` 76.5 tok/s vs `mlx-lm` 77.2 tok/s.
+- Agent workload, 8 concurrent requests, improved to median TTFT 597.1 ms, p95 TTFT 1001.9 ms, median decode throughput 11.00 tok/s, aggregate throughput 83.28 tok/s, wall time 12.30 s.
+
+**Status:** PROMISING. This is the first Python-level batching change that materially improved the concurrent agent workload. The remaining question is how much more benefit we can get by widening the compatibility rule or moving the same idea into MLX itself.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,17 +2,21 @@
 
 **High-throughput local inference server for Apple Silicon.**
 
-mlxz serves LLMs on your Mac with vLLM-class features over an OpenAI-compatible API.
+mlxz serves LLMs on your Mac by porting useful vLLM-class serving ideas to MLX and keeping only the ones that move benchmarks.
 
 ## Features
 
 - **OpenAI API** — Drop-in replacement for `openai-python` SDK
 - **Prefix Caching** — 3x TTFT improvement on repeated prompts
 - **Continuous Batching** — Serve multiple concurrent requests
-- **Speculative Decoding** — 1.5-2.5x effective throughput with draft model
-- **Paged Attention** — Memory-efficient KV cache with reference counting
+- **Speculative Decoding** — Runtime-selectable draft/target engine
+- **Paged Attention Modules** — Experimental block-manager + paged KV components
 - **Admission Control** — Prevents OOM under load
 - **Production Observability** — Prometheus metrics, structured logging
+
+## Thesis
+
+The project is engine-first. The public API and observability are support systems for the real goal: better TTFT, decode throughput, concurrency, and correctness on Apple Silicon. Start with [whitepaper.md](whitepaper.md) for the explicit thesis.
 
 ## Quick Start
 

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -1,0 +1,41 @@
+# MLXZ Thesis
+
+mlxz exists to answer a narrow question: which serving ideas from vLLM can be made to work well on MLX on Apple Silicon, and which of them actually move measured performance?
+
+The project is engine-first. The API, observability, and benchmark harness matter because they let us prove whether an optimization is real. They are not the product.
+
+## What We Are Trying To Port
+
+- Continuous batching for concurrent requests
+- Chunked prefill so long prompts do not monopolize the engine
+- Prefix caching so repeated system prompts avoid redundant prefill
+- Speculative decoding when the draft/target pair is compatible
+- Paged or block-managed KV state for longer contexts
+- Shape-bucketed compilation where MLX benefits from stable execution shapes
+- Token-delivery batching so transport overhead does not erase compute wins
+
+## What Success Looks Like
+
+- Better TTFT on repeated-prefix and agent-style workloads
+- Better aggregate throughput under concurrency
+- No correctness regressions in sampling, stop handling, or determinism contracts
+- Reproducible benchmark results across multiple models, not just one headline model
+- Clear evidence when an idea does not help on MLX, so we stop claiming it
+
+## What We Should Not Drift Into
+
+- Feature shipping without a benchmark
+- Marketing a runtime feature that is not actually wired end to end
+- Treating infra work as the goal instead of the measurement system
+- Keeping dead experiments around without documenting why they failed
+
+## Operational Rule
+
+Every meaningful engine change should answer one of these:
+
+1. Does it improve TTFT?
+2. Does it improve decode throughput?
+3. Does it improve concurrency or memory fit?
+4. Does it improve correctness or benchmark credibility?
+
+If the answer is no, it is probably a doc change, not an engine change.

--- a/src/mlxz/api/app.py
+++ b/src/mlxz/api/app.py
@@ -7,6 +7,7 @@ configures a lifespan context manager for startup/shutdown orchestration.
 
 from __future__ import annotations
 
+import os
 import threading
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -40,6 +41,14 @@ _AUTH_EXEMPT_PATHS: set[str] = {
 }
 
 
+def _parse_bind(bind: str) -> tuple[str, int]:
+    """Parse host:port bind string."""
+    host, sep, port_str = bind.rpartition(":")
+    if sep == "" or not host:
+        raise ValueError(f"Invalid bind address: {bind!r}")
+    return host, int(port_str)
+
+
 def create_app(config: RuntimeConfig) -> FastAPI:
     """Build and return a fully-configured :class:`FastAPI` application.
 
@@ -65,13 +74,18 @@ def create_app(config: RuntimeConfig) -> FastAPI:
         logger.info("server_starting", model=config.model)
 
         # --- Startup ---
-        from mlxz.engine.request import Request
-        from mlxz.engine.single_stream import SingleStreamEngine
         from mlxz.engine.continuous import ContinuousBatchingEngine
+        from mlxz.engine.single_stream import SingleStreamEngine
+        from mlxz.engine.speculative import SpeculativeEngine
         from mlxz.engine.thread_boundary import CancellationRegistry, RequestBridge
         from mlxz.loader.safetensors_store import ModelStore
+        from mlxz.profile.hardware import detect_hardware
         from mlxz.profile.residency import ResidencyPlanner
         from mlxz.scheduler.admission import AdmissionController
+        from mlxz.telemetry.db import create_engine_from_config
+        from mlxz.telemetry.recorder import TelemetryRecorder
+        from mlxz.api.metrics import create_metrics_app
+        import uvicorn
 
         # 1. Load model
         store = ModelStore()
@@ -82,11 +96,28 @@ def create_app(config: RuntimeConfig) -> FastAPI:
         planner = ResidencyPlanner()
         budget = planner.plan_for(weight_bytes, config)
 
-        # 3. Create engine — select based on max_concurrent_requests
+        # 3. Create engine — select based on runtime mode
         bridge = RequestBridge()
         cancellations = CancellationRegistry()
+        use_speculative = config.speculative.enabled
         use_continuous = config.scheduler.max_concurrent_requests > 1
-        if use_continuous:
+        if use_speculative:
+            draft_model_path = config.speculative.draft_model or config.draft_model
+            if draft_model_path is None:
+                raise ValueError(
+                    "speculative.enabled=true requires speculative.draft_model "
+                    "or draft_model to be set"
+                )
+            engine = SpeculativeEngine(config, bridge, cancellations)
+            draft_model, draft_tokenizer, _ = store.load(draft_model_path)
+            engine.set_draft_model(draft_model, draft_tokenizer)
+            logger.info(
+                "engine_mode",
+                mode="speculative",
+                draft_model=draft_model_path,
+                draft_k=config.speculative.num_draft_tokens,
+            )
+        elif use_continuous:
             engine = ContinuousBatchingEngine(config, bridge, cancellations)
             logger.info("engine_mode", mode="continuous_batching",
                         max_batch=config.scheduler.max_concurrent_requests)
@@ -113,7 +144,11 @@ def create_app(config: RuntimeConfig) -> FastAPI:
                 disk_budget_bytes=int(config.prefix_cache.disk_budget_gb * 1024**3),
                 model_hash=model_hash,
             )
-        engine.set_prefix_cache(memory_cache=memory_cache, disk_cache=disk_cache)
+        engine.set_prefix_cache(
+            memory_cache=memory_cache,
+            disk_cache=disk_cache,
+            block_size=config.prefix_cache.block_size,
+        )
 
         # 4. Create admission controller
         n_layers, n_heads, head_dim = engine.model_arch
@@ -138,7 +173,53 @@ def create_app(config: RuntimeConfig) -> FastAPI:
         )
         engine_thread.start()
 
-        # 7. Mark as ready
+        # 7. Start metrics server on separate bind address
+        metrics_server = None
+        metrics_thread = None
+        try:
+            metrics_host, metrics_port = _parse_bind(config.server.metrics_bind)
+            metrics_server = uvicorn.Server(
+                uvicorn.Config(
+                    create_metrics_app(),
+                    host=metrics_host,
+                    port=metrics_port,
+                    log_level="warning",
+                    access_log=False,
+                )
+            )
+            metrics_thread = threading.Thread(
+                target=metrics_server.run,
+                name="mlxz-metrics",
+                daemon=True,
+            )
+            metrics_thread.start()
+            logger.info("metrics_server_started", bind=config.server.metrics_bind)
+        except Exception:
+            logger.warning(
+                "metrics_server_start_failed",
+                bind=config.server.metrics_bind,
+                exc_info=True,
+            )
+
+        # 8. Start telemetry recorder
+        telemetry = None
+        telemetry_run_id = None
+        try:
+            telemetry = TelemetryRecorder(create_engine_from_config())
+            hw = detect_hardware()
+            telemetry_run_id = telemetry.start_run(
+                config,
+                hardware=f"{hw.chip_name}|{hw.memory_gb}GB",
+                commit_sha=os.environ.get("GITHUB_SHA", "local"),
+            )
+            logger.info("telemetry_started", run_id=telemetry_run_id)
+        except Exception:
+            logger.warning("telemetry_start_failed", exc_info=True)
+
+        app.state.telemetry = telemetry
+        app.state.telemetry_run_id = telemetry_run_id
+
+        # 9. Mark as ready
         _health_state.phase = ServerPhase.READY
         _health_state.engine_alive = True
         _health_state.load_progress = 1.0
@@ -154,6 +235,17 @@ def create_app(config: RuntimeConfig) -> FastAPI:
         await engine.shutdown()
         engine_thread.join(timeout=5)
         bridge.close()
+
+        if metrics_server is not None:
+            metrics_server.should_exit = True
+        if metrics_thread is not None:
+            metrics_thread.join(timeout=5)
+
+        if telemetry is not None and telemetry_run_id is not None:
+            try:
+                telemetry.end_run(telemetry_run_id)
+            finally:
+                telemetry.close(timeout=5.0)
 
         _health_state.phase = ServerPhase.STOPPED
         logger.info("server_stopped")

--- a/src/mlxz/api/openai.py
+++ b/src/mlxz/api/openai.py
@@ -7,6 +7,7 @@ endpoints that are wire-compatible with the ``openai-python`` SDK (>= 1.0).
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Any
 
 import structlog
@@ -30,10 +31,9 @@ from mlxz.api.schemas import (
     UsageInfo,
 )
 from mlxz.engine.request import Request as EngineRequest
-from mlxz.engine.single_stream import SingleStreamEngine
 from mlxz.engine.thread_boundary import CancellationRegistry
 from mlxz.scheduler.admission import AdmissionController
-from mlxz.types import AdmissionDecision, RequestState, SamplingParams
+from mlxz.types import AdmissionDecision, EngineProtocol, RequestState, SamplingParams
 
 logger = structlog.get_logger()
 
@@ -43,6 +43,8 @@ router = APIRouter(tags=["openai"])
 openai_router = router
 
 _DEFAULT_TIMEOUT = 300.0  # 5 minutes
+_TOKEN_CHANNEL_DEPTH = 512
+_SSE_TOKEN_BATCH = 16
 
 
 # ---------------------------------------------------------------------------
@@ -50,7 +52,7 @@ _DEFAULT_TIMEOUT = 300.0  # 5 minutes
 # ---------------------------------------------------------------------------
 
 
-def get_engine(request: StarletteRequest) -> SingleStreamEngine:
+def get_engine(request: StarletteRequest) -> EngineProtocol:
     """Retrieve the engine from application state."""
     return request.app.state.engine
 
@@ -70,6 +72,14 @@ def get_cancellations(request: StarletteRequest) -> CancellationRegistry:
     return request.app.state.cancellations
 
 
+def get_telemetry(request: StarletteRequest) -> tuple[Any | None, int | None]:
+    """Retrieve optional telemetry recorder state."""
+    return (
+        getattr(request.app.state, "telemetry", None),
+        getattr(request.app.state, "telemetry_run_id", None),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers (DRY)
 # ---------------------------------------------------------------------------
@@ -84,7 +94,7 @@ def _normalize_stop(stop: str | list[str] | None) -> list[str]:
 
 def _check_admission(
     admission: AdmissionController,
-    engine: SingleStreamEngine,
+    engine: EngineProtocol,
     prompt_token_count: int,
     max_tokens: int,
 ) -> None:
@@ -92,6 +102,12 @@ def _check_admission(
     snap = engine.snapshot()
     decision, reason = admission.decide(prompt_token_count, max_tokens, snap)
     if decision != AdmissionDecision.ACCEPT:
+        try:
+            from mlxz.api.metrics import admission_rejections_total
+
+            admission_rejections_total.labels(reason=decision.name.lower()).inc()
+        except Exception:
+            pass
         raise HTTPException(
             status_code=429,
             detail={
@@ -162,6 +178,57 @@ def _make_usage(eng_request: EngineRequest) -> UsageInfo:
     )
 
 
+def _record_request_telemetry(
+    telemetry: Any | None,
+    run_id: int | None,
+    eng_request: EngineRequest,
+) -> None:
+    """Best-effort telemetry capture for completed/cancelled requests."""
+    if telemetry is None or run_id is None:
+        return
+    try:
+        telemetry.record_request(
+            run_id,
+            request_id=eng_request.id,
+            prompt_tokens=eng_request.prompt_token_count,
+            completion_tokens=eng_request.completion_token_count,
+            prefix_cache_hit_tokens=eng_request.prefix_cache_hit_tokens,
+            ttft_ms=eng_request.ttft_ms,
+            decode_tps=eng_request.decode_tps,
+        )
+    except Exception:
+        logger.warning("telemetry_record_request_failed", request_id=eng_request.id, exc_info=True)
+
+
+def _observe_http_metrics(endpoint: str, status_code: int, duration_seconds: float) -> None:
+    """Best-effort Prometheus request metrics."""
+    try:
+        from mlxz.api.metrics import request_duration_seconds, requests_total
+
+        requests_total.labels(endpoint=endpoint, status=str(status_code)).inc()
+        request_duration_seconds.labels(endpoint=endpoint).observe(duration_seconds)
+    except Exception:
+        pass
+
+
+def _inc_active_requests() -> None:
+    try:
+        from mlxz.api.metrics import active_requests
+
+        active_requests.inc()
+    except Exception:
+        pass
+
+
+def _dec_active_requests() -> None:
+    try:
+        from mlxz.api.metrics import active_requests
+
+        active_requests.dec()
+    except Exception:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # SSE streaming helper
 # ---------------------------------------------------------------------------
@@ -171,9 +238,13 @@ async def _sse_stream(
     request: EngineRequest,
     model_name: str,
     cancellations: CancellationRegistry,
+    started_at: float,
+    telemetry: Any | None = None,
+    telemetry_run_id: int | None = None,
 ):
     """Async generator yielding SSE-formatted chat completion chunks."""
     request_id = f"chatcmpl-{request.id}"
+    status_code = 200
     try:
         # First chunk: role
         role_chunk = ChatCompletionChunk(
@@ -206,17 +277,51 @@ async def _sse_stream(
                 yield "data: [DONE]\n\n"
                 return
 
+            parts = [token.text]
+            saw_eos = False
+            for _ in range(_SSE_TOKEN_BATCH - 1):
+                try:
+                    maybe_token = request.output_channel.async_q.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if maybe_token is None:
+                    saw_eos = True
+                    break
+                parts.append(maybe_token.text)
+
             content_chunk = ChatCompletionChunk(
                 id=request_id,
                 model=model_name,
                 choices=[
                     ChatCompletionChunkChoice(
-                        delta=ChatCompletionChunkDelta(content=token.text)
+                        delta=ChatCompletionChunkDelta(content="".join(parts))
                     )
                 ],
             )
             yield f"data: {content_chunk.model_dump_json()}\n\n"
+            if saw_eos:
+                final_chunk = ChatCompletionChunk(
+                    id=request_id,
+                    model=model_name,
+                    choices=[
+                        ChatCompletionChunkChoice(
+                            delta=ChatCompletionChunkDelta(),
+                            finish_reason=request.finish_reason,
+                        )
+                    ],
+                    usage=_make_usage(request),
+                )
+                yield f"data: {final_chunk.model_dump_json()}\n\n"
+                yield "data: [DONE]\n\n"
+                return
     finally:
+        _observe_http_metrics(
+            endpoint="/v1/chat/completions",
+            status_code=status_code,
+            duration_seconds=time.perf_counter() - started_at,
+        )
+        _record_request_telemetry(telemetry, telemetry_run_id, request)
+        _dec_active_requests()
         cancellations.cancel(request.id)
         cancellations.unregister(request.id)
 
@@ -229,12 +334,15 @@ async def _sse_stream(
 @router.post("/v1/chat/completions")
 async def chat_completions(
     body: ChatCompletionRequest,
-    engine: SingleStreamEngine = Depends(get_engine),
+    engine: EngineProtocol = Depends(get_engine),
     admission: AdmissionController = Depends(get_admission),
     tokenizer: Any = Depends(get_tokenizer),
     cancellations: CancellationRegistry = Depends(get_cancellations),
+    telemetry_state: tuple[Any | None, int | None] = Depends(get_telemetry),
 ):
     """OpenAI-compatible chat completion endpoint."""
+    t0 = time.perf_counter()
+    status_code = 200
     prompt_tokens = _tokenize_chat(tokenizer, body.messages)
     max_tokens = body.max_tokens or 512
     sampling = _build_sampling(body.temperature, body.top_p, body.seed)
@@ -246,23 +354,32 @@ async def chat_completions(
         prompt_tokens=prompt_tokens,
         max_tokens=max_tokens,
         sampling=sampling,
+        return_logprob=bool(body.logprobs),
         stop_sequences=stop_sequences,
-        channel_depth=64,
+        channel_depth=_TOKEN_CHANNEL_DEPTH,
     )
     eng_request.transition(RequestState.ADMITTED)
     cancellations.register(eng_request.id)
+    _inc_active_requests()
     await engine.submit(eng_request)
 
     model_name = body.model
+    telemetry, telemetry_run_id = telemetry_state
 
-    if body.stream:
-        return StreamingResponse(
-            _sse_stream(eng_request, model_name, cancellations),
-            media_type="text/event-stream",
-        )
-
-    # Non-streaming: collect all tokens with timeout
     try:
+        if body.stream:
+            return StreamingResponse(
+                _sse_stream(
+                    eng_request,
+                    model_name,
+                    cancellations,
+                    t0,
+                    telemetry,
+                    telemetry_run_id,
+                ),
+                media_type="text/event-stream",
+            )
+
         generated_text_parts = await _collect_tokens(eng_request)
         return ChatCompletionResponse(
             id=f"chatcmpl-{eng_request.id}",
@@ -279,20 +396,37 @@ async def chat_completions(
             ],
             usage=_make_usage(eng_request),
         )
+    except HTTPException as exc:
+        status_code = exc.status_code
+        raise
+    except Exception:
+        status_code = 500
+        raise
     finally:
-        cancellations.cancel(eng_request.id)
-        cancellations.unregister(eng_request.id)
+        if not body.stream:
+            _observe_http_metrics(
+                endpoint="/v1/chat/completions",
+                status_code=status_code,
+                duration_seconds=time.perf_counter() - t0,
+            )
+            _record_request_telemetry(telemetry, telemetry_run_id, eng_request)
+            _dec_active_requests()
+            cancellations.cancel(eng_request.id)
+            cancellations.unregister(eng_request.id)
 
 
 @router.post("/v1/completions")
 async def completions(
     body: CompletionRequest,
-    engine: SingleStreamEngine = Depends(get_engine),
+    engine: EngineProtocol = Depends(get_engine),
     admission: AdmissionController = Depends(get_admission),
     tokenizer: Any = Depends(get_tokenizer),
     cancellations: CancellationRegistry = Depends(get_cancellations),
+    telemetry_state: tuple[Any | None, int | None] = Depends(get_telemetry),
 ):
     """OpenAI-compatible text completion endpoint."""
+    t0 = time.perf_counter()
+    status_code = 200
     prompt_text = body.prompt if isinstance(body.prompt, str) else body.prompt[0]
     prompt_tokens: list[int] = tokenizer.encode(prompt_text)
     max_tokens = body.max_tokens or 16
@@ -305,12 +439,15 @@ async def completions(
         prompt_tokens=prompt_tokens,
         max_tokens=max_tokens,
         sampling=sampling,
+        return_logprob=False,
         stop_sequences=stop_sequences,
-        channel_depth=64,
+        channel_depth=_TOKEN_CHANNEL_DEPTH,
     )
     eng_request.transition(RequestState.ADMITTED)
     cancellations.register(eng_request.id)
+    _inc_active_requests()
     await engine.submit(eng_request)
+    telemetry, telemetry_run_id = telemetry_state
 
     try:
         generated_text_parts = await _collect_tokens(eng_request)
@@ -326,18 +463,32 @@ async def completions(
             ],
             usage=_make_usage(eng_request),
         )
+    except HTTPException as exc:
+        status_code = exc.status_code
+        raise
+    except Exception:
+        status_code = 500
+        raise
     finally:
+        _observe_http_metrics(
+            endpoint="/v1/completions",
+            status_code=status_code,
+            duration_seconds=time.perf_counter() - t0,
+        )
+        _record_request_telemetry(telemetry, telemetry_run_id, eng_request)
+        _dec_active_requests()
         cancellations.cancel(eng_request.id)
         cancellations.unregister(eng_request.id)
 
 
 @router.get("/v1/models")
 async def list_models(
-    engine: SingleStreamEngine = Depends(get_engine),
+    engine: EngineProtocol = Depends(get_engine),
 ) -> ModelListResponse:
     """List available models."""
+    model_name = getattr(engine, "model_name", "unknown")
     return ModelListResponse(
         data=[
-            ModelInfo(id=engine.model_name),
+            ModelInfo(id=model_name),
         ]
     )

--- a/src/mlxz/cli/bench.py
+++ b/src/mlxz/cli/bench.py
@@ -62,6 +62,8 @@ def bench(
                         "messages": [{"role": "user", "content": prompt}],
                         "max_tokens": max_tokens,
                         "stream": True,
+                        "temperature": 0,
+                        "seed": 42,
                     },
                 ) as resp:
                     for line in resp.iter_lines():

--- a/src/mlxz/cli/serve.py
+++ b/src/mlxz/cli/serve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 from typing import Annotated
 
@@ -15,6 +16,14 @@ def serve(
     model: Annotated[str, typer.Argument(help="HuggingFace repo ID or local path")],
     host: Annotated[str, typer.Option(help="Bind address")] = "127.0.0.1",
     port: Annotated[int, typer.Option(help="Bind port")] = 8000,
+    max_concurrent_requests: Annotated[
+        int | None,
+        typer.Option(
+            "--max-concurrent-requests",
+            min=1,
+            help="Override scheduler concurrency (set to 1 for single-stream baseline)",
+        ),
+    ] = None,
     api_key: Annotated[
         str | None, typer.Option(envvar="MLXZ_API_KEY", help="Bearer auth key")
     ] = None,
@@ -23,14 +32,42 @@ def serve(
     ] = None,
 ) -> None:
     """Start the mlxz inference server."""
-    from mlxz.config import RuntimeConfig, ServerConfig
+    from mlxz.config import RuntimeConfig, SchedulerConfig, ServerConfig
     from mlxz.api.app import create_app
 
-    server_kwargs: dict = {"host": host, "port": port}
+    config_kwargs: dict = {"model": model}
+    if config_file is not None:
+        if not config_file.exists():
+            raise typer.BadParameter(f"Config file not found: {config_file}")
+        with config_file.open("rb") as f:
+            loaded = tomllib.load(f)
+        if not isinstance(loaded, dict):
+            raise typer.BadParameter("Config file must contain a top-level table")
+        config_kwargs.update(loaded)
+
+    server_from_file = config_kwargs.get("server", {})
+    if not isinstance(server_from_file, dict):
+        raise typer.BadParameter("'server' section in config must be a table")
+
+    scheduler_from_file = config_kwargs.get("scheduler", {})
+    if not isinstance(scheduler_from_file, dict):
+        raise typer.BadParameter("'scheduler' section in config must be a table")
+
+    server_kwargs: dict = {
+        **server_from_file,
+        "host": host,
+        "port": port,
+    }
     if api_key:
         server_kwargs["api_key"] = SecretStr(api_key)
+    config_kwargs["server"] = ServerConfig(**server_kwargs)
 
-    config = RuntimeConfig(model=model, server=ServerConfig(**server_kwargs))
+    scheduler_kwargs: dict = dict(scheduler_from_file)
+    if max_concurrent_requests is not None:
+        scheduler_kwargs["max_concurrent_requests"] = max_concurrent_requests
+    config_kwargs["scheduler"] = SchedulerConfig(**scheduler_kwargs)
+
+    config = RuntimeConfig(**config_kwargs)
 
     app = create_app(config)
 

--- a/src/mlxz/config.py
+++ b/src/mlxz/config.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from typing import Literal, Self
 
 from pydantic import BaseModel, Field, SecretStr, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    TomlConfigSettingsSource,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -46,6 +51,7 @@ class PrefixCacheConfig(BaseModel):
     disk_budget_gb: float = Field(default=50.0, gt=0)
     disk_path: Path = Path.home() / ".cache/mlxz/prefix"
     disk_tier_enabled: bool = True
+    block_size: int = Field(default=8, ge=1, le=256)
 
     # NOTE: At runtime the engine appends a model-name hash to ``disk_path``
     # so that different models never share on-disk prefix data.
@@ -145,3 +151,21 @@ class RuntimeConfig(BaseSettings):
     speculative: SpeculativeConfig = Field(default_factory=SpeculativeConfig)
     scheduler: SchedulerConfig = Field(default_factory=SchedulerConfig)
     server: ServerConfig = Field(default_factory=ServerConfig)
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Enable TOML loading in addition to init kwargs and environment."""
+        return (
+            init_settings,
+            env_settings,
+            dotenv_settings,
+            file_secret_settings,
+            TomlConfigSettingsSource(settings_cls),
+        )

--- a/src/mlxz/engine/continuous.py
+++ b/src/mlxz/engine/continuous.py
@@ -11,6 +11,10 @@ import mlx.nn as nn
 import structlog
 
 from mlxz.config import RuntimeConfig
+from mlxz.engine.decode_compiler import (
+    build_compiled_greedy_chunk,
+    build_compiled_greedy_step,
+)
 from mlxz.engine.request import Request, Token
 from mlxz.engine.sampling import sample
 from mlxz.engine.thread_boundary import CancellationRegistry, MxEvalGuard, RequestBridge
@@ -22,8 +26,11 @@ from mlxz.types import (
     ResidencyBudget,
     ThermalState,
 )
+from mlx.utils import tree_flatten, tree_map, tree_unflatten
 
 logger = structlog.get_logger()
+
+_SINGLE_REQUEST_GREEDY_CHUNK_SIZE = 16
 
 
 class ContinuousBatchingEngine:
@@ -113,7 +120,7 @@ class ContinuousBatchingEngine:
         self,
         memory_cache: PrefixCacheMemory | None = None,
         disk_cache: PrefixCacheDisk | None = None,
-        block_size: int = 256,
+        block_size: int = 8,
     ) -> None:
         """Configure prefix cache tiers. Called from lifespan after model load."""
         self._prefix_cache_memory = memory_cache
@@ -188,6 +195,7 @@ class ContinuousBatchingEngine:
                 rng_key=(
                     mx.random.key(request.sampling.seed)
                     if request.sampling.seed is not None
+                    and request.sampling.temperature != 0.0
                     else None
                 ),
             )
@@ -274,6 +282,7 @@ class ContinuousBatchingEngine:
                 logits = self._model(input_ids, cache=active.cache)
                 mx.eval(logits)
             ttft = time.perf_counter() - t0
+            request.ttft_ms = ttft * 1000.0
 
             # Store in prefix cache on miss
             if n_prefix_tokens == 0 and self._prefix_cache_memory is not None and token_hashes:
@@ -282,6 +291,7 @@ class ContinuousBatchingEngine:
                         token_hashes,
                         active.cache,
                         n_tokens=len(request.prompt_tokens),
+                        block_size=self._prefix_hasher.block_size if self._prefix_hasher else 8,
                     )
                 except Exception:
                     log.warning("prefix_cache_store_failed", exc_info=True)
@@ -297,15 +307,13 @@ class ContinuousBatchingEngine:
                 logits[:, -1, :], request.sampling, active.rng_key
             )
             token_text = self._tokenizer.decode([token_id])
-            try:
-                request.output_channel.sync_q.put_nowait(
-                    Token(token_id, token_text, logprob)
-                )
-            except Exception:
-                pass
+            request.output_channel.sync_q.put(
+                Token(token_id, token_text, logprob)
+            )
             request.completion_token_count = 1
             active.last_token_id = token_id
             active.prefill_done = True
+            active.decode_started_at = time.perf_counter()
             request.transition(RequestState.DECODING)
 
             # Track KV for first generated token
@@ -345,124 +353,310 @@ class ContinuousBatchingEngine:
         eos_token_id = getattr(self._tokenizer, "eos_token_id", None)
         kv_per_token = self._kv_bytes_per_token()
         step_kv = int(kv_per_token)
+        tokenizer_decode = self._tokenizer.decode
 
-        # Fast path: single request — prefetch decode loop (mlx-lm style)
-        # All model forward + sampling inside mx.stream() to avoid cache race.
-        if len(decoding) == 1:
+        decode_groups: dict[int, list[tuple[str, _ActiveRequest]]] = {}
+        for req_id, active in decoding:
+            decode_groups.setdefault(_cache_offset(active.cache), []).append(
+                (req_id, active)
+            )
+
+        # Fast path: single request — compiled greedy decode loop.
+        # Uses MLX compile for the hottest decode path when logprobs are not
+        # requested. This keeps the common single-request case competitive while
+        # leaving multi-request batching untouched.
+        if (
+            len(decoding) == 1
+            and len(self._running) == 1
+            and decoding[0][1].request.sampling.temperature == 0.0
+            and not decoding[0][1].request.sampling.return_logprob
+        ):
             req_id, active = decoding[0]
             request = active.request
             stop_checker = request._stop_checker
-            gen_stream = mx.new_stream(mx.default_device())
+            chunked_fast_path = stop_checker is None
+            compiled_chunk = None
+            compiled_chunk_state = None
+            try:
+                if chunked_fast_path:
+                    compiled_chunk, compiled_chunk_state = build_compiled_greedy_chunk(
+                        self._model,
+                        active.cache,
+                        chunk_size=_SINGLE_REQUEST_GREEDY_CHUNK_SIZE,
+                    )
+                    compiled_step = None
+                    compiled_state = None
+                else:
+                    compiled_step, compiled_state = build_compiled_greedy_step(
+                        self._model, active.cache
+                    )
+            except Exception:
+                logger.warning(
+                    "decode_compile_failed", request_id=req_id, exc_info=True
+                )
+                compiled_step = None
+                compiled_state = None
+                compiled_chunk = None
+                compiled_chunk_state = None
 
-            def _fast_step(y_arr):
-                with mx.stream(gen_stream):
-                    logits = self._model(y_arr[None], cache=active.cache)
-                    logits = logits[:, -1, :]
-                    token = mx.argmax(logits, axis=-1)
-                    return token
+            if (
+                compiled_chunk is None
+                and compiled_chunk_state is None
+                and (compiled_step is None or compiled_state is None)
+            ):
+                # Fall back to the prior synchronous greedy decode path.
+                pass
+            else:
+                for _ in range(32):
+                    if request.completion_token_count >= request.max_tokens:
+                        request.finish_reason = "length"
+                        request.transition(RequestState.COMPLETED)
+                        return
+                    if eos_token_id is not None and active.last_token_id == eos_token_id:
+                        request.finish_reason = "stop"
+                        request.transition(RequestState.COMPLETED)
+                        return
+                    if self._cancellations.is_cancelled(req_id):
+                        return
+                    if stop_checker is not None:
+                        last_text = tokenizer_decode([active.last_token_id])
+                        should_stop, _ = stop_checker.check(last_text)
+                        if should_stop:
+                            request.finish_reason = "stop"
+                            request.transition(RequestState.COMPLETED)
+                            return
 
-            # Start first prefetch
-            y = mx.array([active.last_token_id])
-            next_y = _fast_step(y)
-            mx.async_eval(next_y)
+                    if compiled_chunk is not None and compiled_chunk_state is not None:
+                        remaining = request.max_tokens - request.completion_token_count
+                        if remaining <= 0:
+                            request.finish_reason = "length"
+                            request.transition(RequestState.COMPLETED)
+                            return
+                        chunk_tokens = compiled_chunk(mx.array([[active.last_token_id]]))
+                        mx.eval(chunk_tokens)
+                        chunk_token_ids = chunk_tokens.tolist()
+                        generated_in_chunk = len(chunk_token_ids)
+                        active.kv_charged += step_kv * generated_in_chunk
+                        self._kv_used_bytes += step_kv * generated_in_chunk
+                        for token_id in chunk_token_ids[:remaining]:
+                            token_text = tokenizer_decode([token_id])
+                            request.output_channel.sync_q.put(
+                                Token(token_id, token_text, None)
+                            )
+                            request.completion_token_count += 1
+                            active.last_token_id = token_id
+                            if eos_token_id is not None and token_id == eos_token_id:
+                                request.finish_reason = "stop"
+                                request.transition(RequestState.COMPLETED)
+                                return
+                        if request.completion_token_count >= request.max_tokens:
+                            request.finish_reason = "length"
+                            request.transition(RequestState.COMPLETED)
+                            return
+                        if not self._bridge._submit_queue.sync_q.empty():
+                            return
+                        continue
 
-            for _ in range(32):
-                if request.completion_token_count >= request.max_tokens:
-                    mx.eval(next_y)  # drain in-flight before exit
-                    request.finish_reason = "length"
-                    request.transition(RequestState.COMPLETED)
-                    return
-                if eos_token_id is not None and active.last_token_id == eos_token_id:
-                    mx.eval(next_y)
-                    request.finish_reason = "stop"
-                    request.transition(RequestState.COMPLETED)
-                    return
-                if self._cancellations.is_cancelled(req_id):
-                    mx.eval(next_y)
-                    return
-                if stop_checker is not None:
-                    last_text = self._tokenizer.decode([active.last_token_id])
-                    should_stop, _ = stop_checker.check(last_text)
-                    if should_stop:
+                    next_token = compiled_step(mx.array([[active.last_token_id]]))
+                    mx.eval(next_token)
+                    token_id = next_token.item()
+                    token_text = tokenizer_decode([token_id])
+                    request.output_channel.sync_q.put(
+                        Token(token_id, token_text, None)
+                    )
+                    request.completion_token_count += 1
+                    active.last_token_id = token_id
+                    active.kv_charged += step_kv
+                    self._kv_used_bytes += step_kv
+
+                    if not self._bridge._submit_queue.sync_q.empty():
+                        return
+                return
+
+        if len(decoding) == 1 and len(self._running) == 1:
+            req_id, active = decoding[0]
+            request = active.request
+            if request.sampling.temperature == 0.0:
+                stop_checker = request._stop_checker
+                gen_stream = mx.new_stream(mx.default_device())
+
+                def _fast_step(y_arr):
+                    with mx.stream(gen_stream):
+                        logits = self._model(y_arr[None], cache=active.cache)
+                        logits = logits[:, -1, :]
+                        token = mx.argmax(logits, axis=-1)
+                        return token
+
+                # Start first prefetch
+                y = mx.array([active.last_token_id])
+                next_y = _fast_step(y)
+                mx.async_eval(next_y)
+
+                for _ in range(32):
+                    if request.completion_token_count >= request.max_tokens:
+                        mx.eval(next_y)  # drain in-flight before exit
+                        request.finish_reason = "length"
+                        request.transition(RequestState.COMPLETED)
+                        return
+                    if eos_token_id is not None and active.last_token_id == eos_token_id:
                         mx.eval(next_y)
                         request.finish_reason = "stop"
                         request.transition(RequestState.COMPLETED)
                         return
+                    if self._cancellations.is_cancelled(req_id):
+                        mx.eval(next_y)
+                        return
+                    if stop_checker is not None:
+                        last_text = tokenizer_decode([active.last_token_id])
+                        should_stop, _ = stop_checker.check(last_text)
+                        if should_stop:
+                            mx.eval(next_y)
+                            request.finish_reason = "stop"
+                            request.transition(RequestState.COMPLETED)
+                            return
 
-                # Wait for prefetched result
-                mx.eval(next_y)
+                    # Wait for prefetched result
+                    mx.eval(next_y)
 
-                # Start NEXT prefetch BEFORE delivery (overlap GPU with Python)
-                next_next_y = _fast_step(next_y)
-                mx.async_eval(next_next_y)
+                    # Start NEXT prefetch BEFORE delivery (overlap GPU with Python)
+                    next_next_y = _fast_step(next_y)
+                    mx.async_eval(next_next_y)
 
-                # Deliver current token
-                token_id = next_y.item()
-                token_text = self._tokenizer.decode([token_id])
-                try:
-                    request.output_channel.sync_q.put_nowait(
+                    # Deliver current token
+                    token_id = next_y.item()
+                    token_text = tokenizer_decode([token_id])
+                    request.output_channel.sync_q.put(
                         Token(token_id, token_text, None)
                     )
-                except Exception:
-                    mx.eval(next_next_y)
-                    return
-                request.completion_token_count += 1
-                active.last_token_id = token_id
-                next_y = next_next_y
+                    request.completion_token_count += 1
+                    active.last_token_id = token_id
+                    active.kv_charged += step_kv
+                    self._kv_used_bytes += step_kv
+                    next_y = next_next_y
 
-                if not self._bridge._submit_queue.sync_q.empty():
-                    mx.eval(next_y)  # drain before yielding
-                    return
-            mx.eval(next_y)  # drain at loop boundary
-            return
+                    if not self._bridge._submit_queue.sync_q.empty():
+                        mx.eval(next_y)  # drain before yielding
+                        return
+                mx.eval(next_y)  # drain at loop boundary
+                return
 
-        # Multi-request path: one token per request per iteration
-        for req_id, active in decoding:
-            request = active.request
+        # Batch compatible requests by their current cache offset.
+        for _, group in decode_groups.items():
+            if len(group) == 1:
+                req_id, active = group[0]
+                request = active.request
 
-            if request.completion_token_count >= request.max_tokens:
-                request.finish_reason = "length"
-                request.transition(RequestState.COMPLETED)
-                continue
+                if request.completion_token_count >= request.max_tokens:
+                    request.finish_reason = "length"
+                    request.transition(RequestState.COMPLETED)
+                    continue
 
-            if eos_token_id is not None and active.last_token_id == eos_token_id:
-                request.finish_reason = "stop"
-                request.transition(RequestState.COMPLETED)
-                continue
-
-            if request._stop_checker is not None:
-                last_text = self._tokenizer.decode([active.last_token_id])
-                should_stop, _ = request._stop_checker.check(last_text)
-                if should_stop:
+                if eos_token_id is not None and active.last_token_id == eos_token_id:
                     request.finish_reason = "stop"
                     request.transition(RequestState.COMPLETED)
                     continue
 
-            if active.rng_key is not None:
-                active.rng_key = mx.random.split(active.rng_key)[0]
+                if request._stop_checker is not None:
+                    last_text = tokenizer_decode([active.last_token_id])
+                    should_stop, _ = request._stop_checker.check(last_text)
+                    if should_stop:
+                        request.finish_reason = "stop"
+                        request.transition(RequestState.COMPLETED)
+                        continue
 
-            with self._guard:
-                logits = self._model(
-                    mx.array([[active.last_token_id]]), cache=active.cache
+                if active.rng_key is not None:
+                    active.rng_key = mx.random.split(active.rng_key)[0]
+
+                with self._guard:
+                    logits = self._model(
+                        mx.array([[active.last_token_id]]), cache=active.cache
+                    )
+                    mx.eval(logits)
+
+                token_id, logprob = sample(
+                    logits[:, -1, :], request.sampling, active.rng_key
                 )
-                mx.eval(logits)
-
-            token_id, logprob = sample(
-                logits[:, -1, :], request.sampling, active.rng_key
-            )
-            token_text = self._tokenizer.decode([token_id])
-
-            try:
-                request.output_channel.sync_q.put_nowait(
+                token_text = tokenizer_decode([token_id])
+                request.output_channel.sync_q.put(
                     Token(token_id, token_text, logprob)
                 )
-            except Exception:
+
+                request.completion_token_count += 1
+                active.last_token_id = token_id
+                active.kv_charged += step_kv
+                self._kv_used_bytes += step_kv
                 continue
 
-            request.completion_token_count += 1
-            active.last_token_id = token_id
-            active.kv_charged += step_kv
-            self._kv_used_bytes += step_kv
+            live_group = []
+            for req_id, active in group:
+                request = active.request
+                if request.completion_token_count >= request.max_tokens:
+                    request.finish_reason = "length"
+                    request.transition(RequestState.COMPLETED)
+                    continue
+                if eos_token_id is not None and active.last_token_id == eos_token_id:
+                    request.finish_reason = "stop"
+                    request.transition(RequestState.COMPLETED)
+                    continue
+                if request._stop_checker is not None:
+                    last_text = tokenizer_decode([active.last_token_id])
+                    should_stop, _ = request._stop_checker.check(last_text)
+                    if should_stop:
+                        request.finish_reason = "stop"
+                        request.transition(RequestState.COMPLETED)
+                        continue
+                live_group.append((req_id, active))
+
+            if not live_group:
+                continue
+
+            # Batch only requests whose current cache length is already aligned.
+            # MLX's cache API still requires a shared offset across the batch.
+            batch_size = len(live_group)
+            batched_cache = _build_batched_cache([active.cache for _, active in live_group])
+            batch_tokens = mx.array([[active.last_token_id] for _, active in live_group])
+            with self._guard:
+                logits = self._model(batch_tokens, cache=batched_cache)
+                mx.eval(logits)
+
+            _scatter_batched_cache(
+                batched_cache, [active.cache for _, active in live_group]
+            )
+
+            token_rows = logits[:, -1, :]
+            greedy_batch = all(
+                active.request.sampling.temperature == 0.0
+                and not active.request.sampling.return_logprob
+                for _, active in live_group
+            )
+            if greedy_batch:
+                next_token_ids = mx.argmax(token_rows, axis=-1).tolist()
+            else:
+                next_token_ids = []
+
+            for row_idx, (req_id, active) in enumerate(live_group):
+                request = active.request
+                if active.rng_key is not None:
+                    active.rng_key = mx.random.split(active.rng_key)[0]
+
+                if greedy_batch:
+                    token_id = int(next_token_ids[row_idx])
+                    logprob = None
+                else:
+                    token_id, logprob = sample(
+                        token_rows[row_idx], request.sampling, active.rng_key
+                    )
+
+                token_text = tokenizer_decode([token_id])
+                request.output_channel.sync_q.put(
+                    Token(token_id, token_text, logprob)
+                )
+                request.completion_token_count += 1
+                active.last_token_id = token_id
+                active.kv_charged += step_kv
+                self._kv_used_bytes += step_kv
+
+        return
 
     def _retire_requests(self) -> None:
         """Remove completed/cancelled requests and free resources."""
@@ -484,10 +678,16 @@ class ContinuousBatchingEngine:
                     pass
 
                 log = logger.bind(request_id=req_id)
+                if active.decode_started_at is not None:
+                    decode_duration = max(
+                        time.perf_counter() - active.decode_started_at, 1e-9
+                    )
+                    request.decode_tps = request.completion_token_count / decode_duration
                 log.info(
                     "request_retired",
                     completion_tokens=request.completion_token_count,
                     finish_reason=request.finish_reason,
+                    decode_tps=round(request.decode_tps, 2),
                     batch_size=len(self._running) - 1,
                 )
 
@@ -558,6 +758,9 @@ class _ActiveRequest:
         "rng_key",
         "last_token_id",
         "kv_charged",
+        "decode_started_at",
+        "compiled_step",
+        "compiled_step_state",
     )
 
     def __init__(
@@ -573,6 +776,9 @@ class _ActiveRequest:
         self.rng_key = rng_key
         self.last_token_id: int = 0
         self.kv_charged: int = 0
+        self.decode_started_at: float | None = None
+        self.compiled_step = None
+        self.compiled_step_state = None
 
 
 # -- Type imports at module level for type checking only -------------------
@@ -581,3 +787,41 @@ class _ActiveRequest:
 from mlxz.prefix_cache.memory import PrefixCacheMemory  # noqa: E402
 from mlxz.prefix_cache.disk import PrefixCacheDisk  # noqa: E402
 from mlxz.prefix_cache.hasher import RollingPrefixHasher  # noqa: E402
+
+
+def _cache_offset(cache: list[Any]) -> int:
+    if not cache:
+        return 0
+    first = cache[0]
+    return int(getattr(first, "offset", 0))
+
+
+def _build_batched_cache(caches: list[list[Any]]) -> list[Any]:
+    """Stack per-request caches into a single batched cache."""
+    batched_cache = caches[0]
+    for layer_idx in range(len(batched_cache)):
+        layer_states = [cache[layer_idx].state for cache in caches]
+        batched_state = tree_map(lambda *xs: mx.concatenate(xs, axis=0), *layer_states)
+        batched_cache[layer_idx].state = batched_state
+    return batched_cache
+
+
+def _scatter_batched_cache(batched_cache: list[Any], caches: list[list[Any]]) -> None:
+    """Split a batched cache back into per-request caches."""
+    batch_size = len(caches)
+    per_layer_states = [
+        _unbatch_tree(layer_cache.state, batch_size) for layer_cache in batched_cache
+    ]
+    for request_idx, cache in enumerate(caches):
+        for layer_idx, layer_cache in enumerate(cache):
+            layer_cache.state = per_layer_states[layer_idx][request_idx]
+
+
+def _unbatch_tree(tree: Any, batch_size: int) -> list[Any]:
+    """Split a batched pytree into one tree per batch element."""
+    leaves = tree_flatten(tree)
+    per_batch: list[list[tuple[str, Any]]] = [[] for _ in range(batch_size)]
+    for path, leaf in leaves:
+        for idx in range(batch_size):
+            per_batch[idx].append((path, mx.expand_dims(leaf[idx], axis=0)))
+    return [tree_unflatten(items) for items in per_batch]

--- a/src/mlxz/engine/decode_compiler.py
+++ b/src/mlxz/engine/decode_compiler.py
@@ -1,0 +1,55 @@
+"""Compiled decode-step helpers for greedy MLX generation."""
+from __future__ import annotations
+
+from functools import partial
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def build_compiled_greedy_step(
+    model: nn.Module,
+    cache: list[Any],
+):
+    """Compile a greedy decode step that returns the next token id.
+
+    The cache state is captured as compiled outputs so KV mutation stays in
+    sync with the model call. This is intended for temperature=0 requests
+    where logprobs are not required.
+    """
+    state = [layer.state for layer in cache]
+
+    @partial(mx.compile, outputs=state)
+    def _step(token_ids: mx.array) -> mx.array:
+        logits = model(token_ids, cache=cache)
+        return mx.argmax(logits[:, -1, :], axis=-1)
+
+    return _step, state
+
+
+def build_compiled_greedy_chunk(
+    model: nn.Module,
+    cache: list[Any],
+    *,
+    chunk_size: int = 16,
+):
+    """Compile a fixed-length greedy decode chunk.
+
+    This unrolls several greedy steps into one compiled call so the model-side
+    decode work amortizes the Python boundary overhead.
+    """
+    state = [layer.state for layer in cache]
+
+    @partial(mx.compile, outputs=state)
+    def _step(token_ids: mx.array) -> mx.array:
+        tokens = []
+        current = token_ids
+        for _ in range(chunk_size):
+            logits = model(current, cache=cache)
+            current = mx.argmax(logits[:, -1, :], axis=-1)
+            tokens.append(current)
+            current = current[:, None]
+        return mx.concatenate(tokens, axis=0)
+
+    return _step, state

--- a/src/mlxz/engine/request.py
+++ b/src/mlxz/engine/request.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import uuid
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import ClassVar
 
 import janus
@@ -65,6 +65,8 @@ class Request:
     prompt_token_count: int = 0
     completion_token_count: int = 0
     prefix_cache_hit_tokens: int = 0
+    ttft_ms: float = 0.0
+    decode_tps: float = 0.0
     finish_reason: str | None = None  # "stop" | "length"
     stop_sequences: list[str] = field(default_factory=list)
     _stop_checker: StopChecker | None = field(default=None, repr=False, init=False)
@@ -103,10 +105,12 @@ class Request:
         prompt_tokens: list[int],
         max_tokens: int,
         sampling: SamplingParams,
+        return_logprob: bool = True,
         stop_sequences: list[str] | None = None,
         channel_depth: int = 64,
     ) -> Request:
         """Factory that creates a Request with a fresh janus channel."""
+        sampling = replace(sampling, return_logprob=return_logprob)
         return Request(
             id=str(uuid.uuid4()),
             prompt_tokens=prompt_tokens,

--- a/src/mlxz/engine/sampling.py
+++ b/src/mlxz/engine/sampling.py
@@ -31,7 +31,7 @@ def sample(
     # Greedy
     if params.temperature == 0.0:
         token_id = mx.argmax(logits).item()
-        logprob = _logprob_for_token(logits, token_id)
+        logprob = _logprob_for_token(logits, token_id) if params.return_logprob else None
         return token_id, logprob
 
     # Save pre-filter logits for accurate logprob computation
@@ -59,7 +59,7 @@ def sample(
         token_id = mx.random.categorical(filtered[None, :]).item()
 
     # Logprob from pre-filter distribution (OpenAI-compatible)
-    logprob = _logprob_for_token(raw_logits, token_id)
+    logprob = _logprob_for_token(raw_logits, token_id) if params.return_logprob else None
     return token_id, logprob
 
 

--- a/src/mlxz/engine/single_stream.py
+++ b/src/mlxz/engine/single_stream.py
@@ -11,6 +11,10 @@ import structlog
 
 from mlxz.config import RuntimeConfig
 from mlxz.engine.request import Request, Token
+from mlxz.engine.decode_compiler import (
+    build_compiled_greedy_chunk,
+    build_compiled_greedy_step,
+)
 from mlxz.engine.sampling import sample
 from mlxz.engine.thread_boundary import CancellationRegistry, MxEvalGuard, RequestBridge
 from mlxz.types import (
@@ -103,7 +107,7 @@ class SingleStreamEngine:
         self,
         memory_cache: PrefixCacheMemory | None = None,
         disk_cache: PrefixCacheDisk | None = None,
-        block_size: int = 256,
+        block_size: int = 8,
     ) -> None:
         """Configure prefix cache tiers. Called from lifespan after model load."""
         self._prefix_cache_memory = memory_cache
@@ -154,6 +158,8 @@ class SingleStreamEngine:
         assert self._guard is not None
 
         log = logger.bind(request_id=request.id)
+        tokenizer_decode = self._tokenizer.decode
+        token_put = request.output_channel.sync_q.put
         log.info(
             "request_processing",
             prompt_tokens=request.prompt_token_count,
@@ -238,6 +244,7 @@ class SingleStreamEngine:
                 mx.eval(logits)
 
             ttft = time.perf_counter() - t0
+            request.ttft_ms = ttft * 1000.0
 
             # --- Store in memory cache on miss ---
             if (
@@ -247,7 +254,10 @@ class SingleStreamEngine:
             ):
                 try:
                     self._prefix_cache_memory.store_sync(
-                        token_hashes, cache, n_tokens=len(request.prompt_tokens)
+                        token_hashes,
+                        cache,
+                        n_tokens=len(request.prompt_tokens),
+                        block_size=self._prefix_hasher.block_size if self._prefix_hasher else 8,
                     )
                 except Exception:
                     log.warning("prefix_cache_store_failed", exc_info=True)
@@ -277,18 +287,63 @@ class SingleStreamEngine:
             # Transition to decoding
             request.transition(RequestState.DECODING)
 
+            greedy_fast_path = (
+                request.sampling.temperature == 0.0
+                and not request.sampling.return_logprob
+            )
+            chunked_fast_path = greedy_fast_path and request._stop_checker is None
+
             # Initialize RNG key for deterministic sampling
             rng_key = (
                 mx.random.key(request.sampling.seed)
                 if request.sampling.seed is not None
+                and request.sampling.temperature != 0.0
                 else None
             )
 
             # First token from prefill logits
-            token_id, logprob = sample(logits[:, -1, :], request.sampling, rng_key)
-            token_text = self._tokenizer.decode([token_id])
-            request.output_channel.sync_q.put(Token(token_id, token_text, logprob))
+            if greedy_fast_path:
+                token_id = mx.argmax(logits[:, -1, :], axis=-1).item()
+                logprob = None
+            else:
+                token_id, logprob = sample(
+                    logits[:, -1, :], request.sampling, rng_key
+                )
+            token_text = tokenizer_decode([token_id])
+            token_put(Token(token_id, token_text, logprob))
             request.completion_token_count = 1
+
+            compiled_step = None
+            compiled_state = None
+            compiled_chunk = None
+            compiled_chunk_state = None
+            decode_start = time.perf_counter()
+            if chunked_fast_path:
+                try:
+                    compiled_chunk, compiled_chunk_state = build_compiled_greedy_chunk(
+                        self._model, cache
+                    )
+                except Exception:
+                    logger.warning(
+                        "decode_compile_failed",
+                        request_id=request.id,
+                        exc_info=True,
+                    )
+                    compiled_chunk = None
+                    compiled_chunk_state = None
+            elif greedy_fast_path:
+                try:
+                    compiled_step, compiled_state = build_compiled_greedy_step(
+                        self._model, cache
+                    )
+                except Exception:
+                    logger.warning(
+                        "decode_compile_failed",
+                        request_id=request.id,
+                        exc_info=True,
+                    )
+                    compiled_step = None
+                    compiled_state = None
 
             # Track KV for first generated token
             step_kv = int(kv_per_token)
@@ -299,7 +354,6 @@ class SingleStreamEngine:
             eos_token_id = getattr(self._tokenizer, "eos_token_id", None)
 
             # Decode loop
-            decode_start = time.perf_counter()
 
             for _step in range(request.max_tokens - 1):
                 # Check cancellation
@@ -325,24 +379,51 @@ class SingleStreamEngine:
                         log.debug("stop_sequence_matched", sequence=matched)
                         break
 
-                # Advance RNG
-                if rng_key is not None:
-                    rng_key = mx.random.split(rng_key)[0]
+                if compiled_chunk is not None and compiled_chunk_state is not None:
+                    remaining = request.max_tokens - request.completion_token_count
+                    if remaining <= 0:
+                        break
+                    chunk_tokens = compiled_chunk(mx.array([[token_id]]))
+                    mx.eval(chunk_tokens)
+                    chunk_token_ids = chunk_tokens.tolist()
+                    generated_in_chunk = len(chunk_token_ids)
+                    kv_charged += step_kv * generated_in_chunk
+                    self._kv_used_bytes += step_kv * generated_in_chunk
+                    for next_token_id in chunk_token_ids[:remaining]:
+                        token_id = next_token_id
+                        logprob = None
+                        token_text = tokenizer_decode([token_id])
+                        token_put(Token(token_id, token_text, logprob))
+                        request.completion_token_count += 1
+                        if eos_token_id is not None and token_id == eos_token_id:
+                            request.finish_reason = "stop"
+                            break
+                    if request.finish_reason == "stop":
+                        break
+                    continue
+                elif compiled_step is not None and compiled_state is not None:
+                    next_token = compiled_step(mx.array([[token_id]]))
+                    mx.eval(next_token)
+                    token_id = next_token.item()
+                    logprob = None
+                else:
+                    # Advance RNG
+                    if rng_key is not None:
+                        rng_key = mx.random.split(rng_key)[0]
 
-                # Decode step
-                with self._guard:
-                    logits = self._model(mx.array([[token_id]]), cache=cache)
-                    mx.eval(logits)
+                    # Decode step
+                    with self._guard:
+                        logits = self._model(mx.array([[token_id]]), cache=cache)
+                        mx.eval(logits)
 
-                token_id, logprob = sample(
-                    logits[:, -1, :], request.sampling, rng_key
-                )
-                token_text = self._tokenizer.decode([token_id])
+                    token_id, logprob = sample(
+                        logits[:, -1, :], request.sampling, rng_key
+                    )
+
+                token_text = tokenizer_decode([token_id])
 
                 # Put token on channel (blocks if full -- backpressure)
-                request.output_channel.sync_q.put(
-                    Token(token_id, token_text, logprob)
-                )
+                token_put(Token(token_id, token_text, logprob))
                 request.completion_token_count += 1
 
                 # Update KV tracking
@@ -361,6 +442,7 @@ class SingleStreamEngine:
                 if decode_duration > 0
                 else 0
             )
+            request.decode_tps = decode_tps
             log.info(
                 "request_completed",
                 completion_tokens=request.completion_token_count,

--- a/src/mlxz/engine/speculative.py
+++ b/src/mlxz/engine/speculative.py
@@ -71,6 +71,12 @@ class SpeculativeEngine:
         # Stats
         self._total_accepted: int = 0
         self._total_proposed: int = 0
+        # Prefix cache is wired through the common app startup path.
+        # Speculative decode currently skips cache reuse and remains functional
+        # without it; the hook exists so engine selection stays uniform.
+        self._prefix_cache_memory = None
+        self._prefix_cache_disk = None
+        self._prefix_hasher = None
 
     @property
     def model_name(self) -> str:
@@ -110,6 +116,26 @@ class SpeculativeEngine:
         """Set the draft model. Must be called before run()."""
         self._draft = DraftModel(draft_model, draft_tokenizer)
 
+    def set_prefix_cache(
+        self,
+        memory_cache: Any | None = None,
+        disk_cache: Any | None = None,
+        block_size: int = 8,
+    ) -> None:
+        """Accept the shared prefix-cache wiring used by app startup.
+
+        Speculative decoding can use prefix caching, but the cache layout differs
+        because we keep both draft and target caches. Leave the hook in place so
+        startup stays uniform and we can add the dual-cache implementation without
+        changing engine selection again.
+        """
+        self._prefix_cache_memory = memory_cache
+        self._prefix_cache_disk = disk_cache
+        if memory_cache is not None or disk_cache is not None:
+            from mlxz.prefix_cache.hasher import RollingPrefixHasher
+
+            self._prefix_hasher = RollingPrefixHasher(block_size=block_size)
+
     def set_budget(self, budget: ResidencyBudget) -> None:
         self._budget = budget
 
@@ -142,20 +168,103 @@ class SpeculativeEngine:
 
             # Create KV caches for both models
             from mlx_lm.models.cache import make_prompt_cache
+
             target_cache = make_prompt_cache(self._target_model)
             draft_cache = make_prompt_cache(self._draft._model)
 
+            # Prefix cache lookup applies to the target model only. The draft
+            # model has different weights, so its KV cache cannot be reused.
+            n_prefix_tokens = 0
+            token_hashes: tuple[bytes, ...] = ()
+            cache_tier = ""
+
+            if self._prefix_hasher is not None:
+                token_hashes = self._prefix_hasher.hash_chunks(request.prompt_tokens)
+
+                if self._prefix_cache_memory is not None:
+                    n_matched, cached_kv = self._prefix_cache_memory.lookup_sync(
+                        token_hashes
+                    )
+                    if cached_kv is not None and n_matched > 0:
+                        n_prefix_tokens = n_matched
+                        cache_tier = "memory"
+                        for layer_cache, cached_state in zip(target_cache, cached_kv):
+                            layer_cache.state = cached_state
+
+                if n_prefix_tokens == 0 and self._prefix_cache_disk is not None:
+                    n_matched, cached_kv = self._prefix_cache_disk.lookup_sync(
+                        token_hashes
+                    )
+                    if cached_kv is not None and n_matched > 0:
+                        n_prefix_tokens = n_matched
+                        cache_tier = "disk"
+                        for layer_cache, cached_state in zip(target_cache, cached_kv):
+                            layer_cache.state = cached_state
+
+                n_prefix_tokens = min(n_prefix_tokens, len(request.prompt_tokens))
+                request.prefix_cache_hit_tokens = n_prefix_tokens
+
+                if n_prefix_tokens > 0:
+                    log.info(
+                        "prefix_cache_hit",
+                        tier=cache_tier,
+                        matched_tokens=n_prefix_tokens,
+                        total_prompt_tokens=len(request.prompt_tokens),
+                    )
+
+            # Determine target-model prompt slice
+            if n_prefix_tokens >= len(request.prompt_tokens):
+                # Full hit -- re-run last token for fresh logits
+                try:
+                    from mlx_lm.models.cache import trim_prompt_cache
+
+                    trim_prompt_cache(target_cache, 1)
+                except ImportError:
+                    for lc in target_cache:
+                        if hasattr(lc, "offset"):
+                            lc.offset = max(0, lc.offset - 1)
+                target_input_ids = mx.array([request.prompt_tokens[-1:]])
+            elif n_prefix_tokens > 0:
+                target_input_ids = mx.array([request.prompt_tokens[n_prefix_tokens:]])
+            else:
+                target_input_ids = mx.array([request.prompt_tokens])
+
+            # Draft model always needs the full prompt because its KV cache is
+            # not compatible with the target model's cached prefix.
+            draft_input_ids = mx.array([request.prompt_tokens])
+
             # Prefill both models
-            input_ids = mx.array([request.prompt_tokens])
             t0 = time.perf_counter()
 
             with self._guard:
-                target_logits = self._target_model(input_ids, cache=target_cache)
-                draft_logits = self._draft._model(input_ids, cache=draft_cache)
+                target_logits = self._target_model(target_input_ids, cache=target_cache)
+                draft_logits = self._draft._model(draft_input_ids, cache=draft_cache)
                 mx.eval(target_logits, draft_logits)
 
             ttft = time.perf_counter() - t0
-            log.info("prefill_complete", ttft_ms=round(ttft * 1000, 2))
+            request.ttft_ms = ttft * 1000.0
+
+            if (
+                n_prefix_tokens == 0
+                and self._prefix_cache_memory is not None
+                and token_hashes
+            ):
+                try:
+                    self._prefix_cache_memory.store_sync(
+                        token_hashes,
+                        target_cache,
+                        n_tokens=len(request.prompt_tokens),
+                        block_size=self._prefix_hasher.block_size if self._prefix_hasher else 8,
+                    )
+                except Exception:
+                    log.warning("prefix_cache_store_failed", exc_info=True)
+
+            log.info(
+                "prefill_complete",
+                ttft_ms=round(ttft * 1000, 2),
+                prefix_cache=("hit" if n_prefix_tokens > 0 else "miss"),
+                prefix_tokens=n_prefix_tokens,
+            )
 
             request.transition(RequestState.DECODING)
 
@@ -168,6 +277,7 @@ class SpeculativeEngine:
             eos_token_id = getattr(self._tokenizer, "eos_token_id", None)
 
             # Speculative decode loop
+            decode_start = time.perf_counter()
             while request.completion_token_count < request.max_tokens:
                 if self._cancellations.is_cancelled(request.id):
                     request.finish_reason = "cancelled"
@@ -273,9 +383,17 @@ class SpeculativeEngine:
                     request.finish_reason = "length"
                 request.transition(RequestState.COMPLETED)
 
+            decode_duration = time.perf_counter() - decode_start
+            request.decode_tps = (
+                request.completion_token_count / decode_duration
+                if decode_duration > 0
+                else 0.0
+            )
+
             log.info("request_completed",
                      completion_tokens=request.completion_token_count,
                      finish_reason=request.finish_reason,
+                     decode_tps=round(request.decode_tps, 2),
                      acceptance_rate=round(self.acceptance_rate, 3),
                      draft_k=self._current_draft_k)
 

--- a/src/mlxz/prefix_cache/hasher.py
+++ b/src/mlxz/prefix_cache/hasher.py
@@ -12,11 +12,12 @@ class RollingPrefixHasher:
     chunk may be partial (fewer than block_size tokens). Returns a tuple
     of bytes (hashable, usable as dict keys).
 
-    Block size of 256 matches mlx-lm's KVCache.step allocation granularity,
-    minimizing waste when restoring partial prefixes.
+    Smaller block sizes increase the chance of reusing short shared prefixes
+    (useful for agent-style workloads). Larger block sizes reduce hash churn
+    and metadata overhead but require longer identical prefixes to hit.
     """
 
-    def __init__(self, block_size: int = 256) -> None:
+    def __init__(self, block_size: int = 8) -> None:
         if block_size < 1:
             raise ValueError(f"block_size must be >= 1, got {block_size}")
         self._block_size = block_size

--- a/src/mlxz/prefix_cache/memory.py
+++ b/src/mlxz/prefix_cache/memory.py
@@ -1,6 +1,7 @@
 """In-memory prefix cache with LRU eviction."""
 from __future__ import annotations
 
+import copy
 import time
 from typing import Any
 
@@ -76,6 +77,7 @@ class PrefixCacheMemory:
         token_hashes: tuple[bytes, ...],
         kv_cache_layers: list[Any],
         n_tokens: int | None = None,
+        block_size: int = 8,
     ) -> None:
         """Store prefix KV data. Deep-copies tensors and evicts LRU if over budget.
 
@@ -85,21 +87,21 @@ class PrefixCacheMemory:
                 property returning the (keys, values) tuple.
             n_tokens: Number of tokens this prefix covers. If None, inferred from
                 the first layer's key tensor shape.
+            block_size: Prefix-cache chunk size used to derive stored prefix keys.
         """
         if token_hashes in self._entries:
             return  # already cached
 
-        # Extract and deep-copy KV states
-        kv_states = []
+        # Extract and deep-copy KV states from a mutable cache snapshot.
         cache_type = type(kv_cache_layers[0]).__name__
-        for layer_cache in kv_cache_layers:
-            state = layer_cache.state  # (keys, values) sliced to offset
-            copied = _deep_copy_kv_states([state])[0]
-            kv_states.append(copied)
+        cache_copy = copy.deepcopy(kv_cache_layers)
+
+        def _snapshot_state(copy_cache: list[Any]) -> list[Any]:
+            return _deep_copy_kv_states([layer_cache.state for layer_cache in copy_cache])
 
         if n_tokens is None:
             # Infer from the first layer's key tensor
-            first_state = kv_states[0]
+            first_state = cache_copy[0].state
             if isinstance(first_state, tuple) and len(first_state) >= 1:
                 keys = first_state[0]
                 if isinstance(keys, mx.array):
@@ -112,28 +114,59 @@ class PrefixCacheMemory:
             else:
                 n_tokens = 0
 
-        size = compute_size_bytes(kv_states)
+        if n_tokens <= 0:
+            return
 
-        # Evict until we have room
-        self._evict_until_room(size)
+        # Store the full prompt state and each chunk boundary prefix so future
+        # requests can hit on shared system-prompt prefixes instead of only
+        # exact full-prompt matches.
+        prefix_lengths: list[int] = list(range(block_size, n_tokens, block_size))
+        if not prefix_lengths or prefix_lengths[-1] != n_tokens:
+            prefix_lengths.append(n_tokens)
 
-        if size > self._budget:
-            logger.warning("prefix_cache_entry_too_large",
-                           entry_bytes=size, budget_bytes=self._budget)
-            return  # single entry exceeds entire budget
+        current_len = n_tokens
+        for prefix_len in reversed(prefix_lengths):
+            if current_len > prefix_len:
+                from mlx_lm.models.cache import trim_prompt_cache
 
-        entry = CachedPrefix(
-            token_hashes=token_hashes,
-            kv_states=kv_states,
-            n_tokens=n_tokens,
-            size_bytes=size,
-            cache_type=cache_type,
-        )
-        self._entries[token_hashes] = entry
-        self._used_bytes += size
-        self._stats.memory_used_bytes = self._used_bytes
-        logger.debug("prefix_cache_memory_stored",
-                     chunks=len(token_hashes), n_tokens=n_tokens, size_bytes=size)
+                trim_prompt_cache(cache_copy, current_len - prefix_len)
+                current_len = prefix_len
+
+            prefix_chunks = prefix_len // block_size
+            if prefix_len % block_size:
+                prefix_chunks += 1
+            prefix_key = token_hashes[:prefix_chunks]
+            if not prefix_key or prefix_key in self._entries:
+                continue
+
+            kv_states = _snapshot_state(cache_copy)
+            size = compute_size_bytes(kv_states)
+
+            self._evict_until_room(size)
+            if size > self._budget:
+                logger.warning(
+                    "prefix_cache_entry_too_large",
+                    entry_bytes=size,
+                    budget_bytes=self._budget,
+                )
+                continue
+
+            entry = CachedPrefix(
+                token_hashes=prefix_key,
+                kv_states=kv_states,
+                n_tokens=prefix_len,
+                size_bytes=size,
+                cache_type=cache_type,
+            )
+            self._entries[prefix_key] = entry
+            self._used_bytes += size
+            self._stats.memory_used_bytes = self._used_bytes
+            logger.debug(
+                "prefix_cache_memory_stored",
+                chunks=len(prefix_key),
+                n_tokens=prefix_len,
+                size_bytes=size,
+            )
 
     def _evict_until_room(self, needed_bytes: int) -> None:
         """Evict LRU entries until there's room for needed_bytes."""

--- a/src/mlxz/types.py
+++ b/src/mlxz/types.py
@@ -30,6 +30,7 @@ class SamplingParams:
     """``-1`` disables top-k filtering."""
     min_p: float = 0.0
     seed: int | None = None
+    return_logprob: bool = True
     stop: list[str] = field(default_factory=list)
     """Stop sequences — generation halts when any is produced."""
 

--- a/tests/correctness/test_generation_correctness.py
+++ b/tests/correctness/test_generation_correctness.py
@@ -1,0 +1,32 @@
+"""Correctness checks for generation primitives used by serving engines."""
+from __future__ import annotations
+
+import mlx.core as mx
+
+from mlxz.engine.request import StopChecker
+from mlxz.engine.sampling import sample
+from mlxz.types import SamplingParams
+
+
+def test_stop_checker_detects_cross_token_boundary() -> None:
+    checker = StopChecker(["</END>"])
+    assert checker.check("Hello </")[0] is False
+    should_stop, matched = checker.check("END> world")
+    assert should_stop is True
+    assert matched == "</END>"
+
+
+def test_sampling_is_seed_reproducible() -> None:
+    logits = mx.array([0.1, 0.2, 0.3, 0.4])
+    params = SamplingParams(temperature=0.8, top_p=1.0, seed=1234)
+
+    def run_sequence() -> list[int]:
+        key = mx.random.key(params.seed)
+        tokens: list[int] = []
+        for _ in range(32):
+            key = mx.random.split(key)[0]
+            tok, _ = sample(logits, params, key)
+            tokens.append(tok)
+        return tokens
+
+    assert run_sequence() == run_sequence()

--- a/tests/integration/test_openai_api.py
+++ b/tests/integration/test_openai_api.py
@@ -325,9 +325,15 @@ class TestChatCompletionsStreaming:
             )
         lines = resp.text.strip().split("\n")
         data_lines = [l for l in lines if l.startswith("data: ") and l != "data: [DONE]"]
-        # Should have: 1 role chunk + 3 content chunks + 1 finish chunk = 5
-        # (role, "Hello", " world", "!", finish)
-        assert len(data_lines) >= 4  # role + at least some content + finish
+        assert len(data_lines) >= 3  # role + content + finish (content may be batched)
+
+        chunks = [json.loads(line.removeprefix("data: ")) for line in data_lines]
+        content = "".join(
+            (chunk["choices"][0]["delta"].get("content") or "")
+            for chunk in chunks
+        )
+        assert content
+        assert content == "Hello world!"
 
     async def test_final_chunk_has_finish_reason(self, mock_app) -> None:
         transport = ASGITransport(app=mock_app)

--- a/tests/integration/test_openai_client_sdk.py
+++ b/tests/integration/test_openai_client_sdk.py
@@ -23,7 +23,9 @@ from mlxz.types import (
 )
 
 openai = pytest.importorskip("openai")
-OpenAI = openai.OpenAI
+AsyncOpenAI = openai.AsyncOpenAI
+
+pytestmark = pytest.mark.anyio
 
 
 class _MockTokenizer:
@@ -83,7 +85,7 @@ def _make_budget() -> ResidencyBudget:
 
 
 @pytest.fixture
-def sdk_client():
+def sdk_app():
     app = FastAPI(title="mlxz-sdk-test")
     app.include_router(health_router)
     app.include_router(openai_router)
@@ -96,49 +98,70 @@ def sdk_client():
     app.state.telemetry = None
     app.state.telemetry_run_id = None
 
-    transport = ASGITransport(app=app)
-    http_client = httpx.Client(transport=transport, base_url="http://test")
-    client = OpenAI(base_url="http://test/v1", api_key="test", http_client=http_client)
-    try:
-        yield client
-    finally:
-        client.close()
+
+@pytest.fixture
+def sdk_transport(sdk_app):
+    return ASGITransport(app=sdk_app)
 
 
-def test_chat_non_streaming(sdk_client) -> None:
-    resp = sdk_client.chat.completions.create(
-        model="mock-model",
-        messages=[{"role": "user", "content": "Say hi"}],
-        max_tokens=3,
-    )
+@pytest.mark.anyio
+async def test_chat_non_streaming(sdk_transport) -> None:
+    async with httpx.AsyncClient(transport=sdk_transport, base_url="http://test") as http_client:
+        client = AsyncOpenAI(base_url="http://test/v1", api_key="test", http_client=http_client)
+        try:
+            resp = await client.chat.completions.create(
+                model="mock-model",
+                messages=[{"role": "user", "content": "Say hi"}],
+                max_tokens=3,
+            )
+        finally:
+            await client.close()
     assert resp.choices[0].message.content == "Hello SDK"
     assert resp.usage.completion_tokens > 0
 
 
-def test_chat_streaming(sdk_client) -> None:
-    stream = sdk_client.chat.completions.create(
-        model="mock-model",
-        messages=[{"role": "user", "content": "Say hi"}],
-        max_tokens=3,
-        stream=True,
-    )
-    parts: list[str] = []
-    for chunk in stream:
-        content = chunk.choices[0].delta.content or ""
-        if content:
-            parts.append(content)
+@pytest.mark.anyio
+async def test_chat_streaming(sdk_transport) -> None:
+    async with httpx.AsyncClient(transport=sdk_transport, base_url="http://test") as http_client:
+        client = AsyncOpenAI(base_url="http://test/v1", api_key="test", http_client=http_client)
+        parts: list[str] = []
+        try:
+            stream = await client.chat.completions.create(
+                model="mock-model",
+                messages=[{"role": "user", "content": "Say hi"}],
+                max_tokens=3,
+                stream=True,
+            )
+            async for chunk in stream:
+                content = chunk.choices[0].delta.content or ""
+                if content:
+                    parts.append(content)
+        finally:
+            await client.close()
     assert "".join(parts) == "Hello SDK"
 
 
-def test_completions_non_streaming(sdk_client) -> None:
-    resp = sdk_client.completions.create(
-        model="mock-model",
-        prompt="Hello",
-        max_tokens=3,
-    )
+@pytest.mark.anyio
+async def test_completions_non_streaming(sdk_transport) -> None:
+    async with httpx.AsyncClient(transport=sdk_transport, base_url="http://test") as http_client:
+        client = AsyncOpenAI(base_url="http://test/v1", api_key="test", http_client=http_client)
+        try:
+            resp = await client.completions.create(
+                model="mock-model",
+                prompt="Hello",
+                max_tokens=3,
+            )
+        finally:
+            await client.close()
     assert resp.choices[0].text == "Hello SDK"
 
 
-def test_list_models(sdk_client) -> None:
-    models = sdk_client.models.list()
+@pytest.mark.anyio
+async def test_list_models(sdk_transport) -> None:
+    async with httpx.AsyncClient(transport=sdk_transport, base_url="http://test") as http_client:
+        client = AsyncOpenAI(base_url="http://test/v1", api_key="test", http_client=http_client)
+        try:
+            models = await client.models.list()
+        finally:
+            await client.close()
     assert models.data[0].id == "mock-model"

--- a/tests/integration/test_openai_client_sdk.py
+++ b/tests/integration/test_openai_client_sdk.py
@@ -1,70 +1,144 @@
-"""End-to-end tests using the openai-python SDK against a live server.
-
-These tests require a running mlxz server with a real model loaded,
-so they are gated behind the ``self_hosted`` marker and skipped in
-standard CI runs.
-
-To run locally::
-
-    pytest -m self_hosted tests/integration/test_openai_client_sdk.py
-
-Prerequisites:
-    - A model downloaded and accessible (e.g. ``mlx-community/Llama-3.2-1B-Instruct-4bit``)
-    - ``pip install openai`` in the test environment
-    - A running ``mlxz`` server (``mlxz serve --model <model>``)
-"""
+"""OpenAI SDK smoke tests against an in-process mlxz ASGI app."""
 from __future__ import annotations
 
+import threading
+
+import httpx
 import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
 
-pytestmark = [
-    pytest.mark.self_hosted,
-    pytest.mark.skip(reason="Requires a running mlxz server with a real model"),
-]
+from mlxz.api.health import router as health_router
+from mlxz.api.openai import router as openai_router
+from mlxz.config import RuntimeConfig
+from mlxz.engine.request import Token
+from mlxz.engine.thread_boundary import CancellationRegistry
+from mlxz.scheduler.admission import AdmissionController
+from mlxz.types import (
+    AdmissionSnapshot,
+    DrainResult,
+    MemoryPressure,
+    ResidencyBudget,
+    ThermalState,
+)
 
-
-class TestChatCompletionSDK:
-    """Verify openai-python SDK works against the mlxz chat completions endpoint."""
-
-    def test_non_streaming(self) -> None:
-        """Non-streaming chat completion via the SDK."""
-        # TODO: Implement when server_process fixture is available.
-        # from openai import OpenAI
-        # client = OpenAI(base_url="http://localhost:8000/v1", api_key="test")
-        # resp = client.chat.completions.create(
-        #     model="test-model",
-        #     messages=[{"role": "user", "content": "Say hello"}],
-        #     max_tokens=16,
-        # )
-        # assert resp.choices[0].message.content
-        # assert resp.usage.completion_tokens > 0
-
-    def test_streaming(self) -> None:
-        """Streaming chat completion via the SDK."""
-        # TODO: Implement when server_process fixture is available.
-        # from openai import OpenAI
-        # client = OpenAI(base_url="http://localhost:8000/v1", api_key="test")
-        # stream = client.chat.completions.create(
-        #     model="test-model",
-        #     messages=[{"role": "user", "content": "Say hello"}],
-        #     max_tokens=16,
-        #     stream=True,
-        # )
-        # chunks = list(stream)
-        # assert len(chunks) > 0
+openai = pytest.importorskip("openai")
+OpenAI = openai.OpenAI
 
 
-class TestCompletionSDK:
-    """Verify openai-python SDK works against the mlxz completions endpoint."""
+class _MockTokenizer:
+    eos_token_id = 2
 
-    def test_non_streaming(self) -> None:
-        """Non-streaming text completion via the SDK."""
-        # TODO: Implement when server_process fixture is available.
+    def apply_chat_template(self, messages, tokenize=True, add_generation_prompt=True):
+        return [1, 2, 3]
+
+    def encode(self, text):
+        return [1, 2, 3]
+
+    def decode(self, tokens):
+        return "x"
 
 
-class TestModelsSDK:
-    """Verify openai-python SDK can list models."""
+class _MockEngine:
+    def __init__(self) -> None:
+        self._model_name = "mock-model"
 
-    def test_list_models(self) -> None:
-        """List models via the SDK."""
-        # TODO: Implement when server_process fixture is available.
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    async def submit(self, request) -> None:
+        threading.Thread(target=self._generate, args=(request,), daemon=True).start()
+
+    def _generate(self, request) -> None:
+        for idx, text in enumerate(["Hello", " ", "SDK"][: request.max_tokens]):
+            request.output_channel.sync_q.put(Token(token_id=idx + 1, text=text))
+            request.completion_token_count += 1
+        request.finish_reason = "stop"
+        request.output_channel.sync_q.put(None)
+
+    def snapshot(self) -> AdmissionSnapshot:
+        return AdmissionSnapshot(
+            kv_used_bytes=0,
+            kv_budget_bytes=10_000_000_000,
+            running_requests=0,
+            queued_requests=0,
+            thermal_state=ThermalState.NORMAL,
+            memory_pressure=MemoryPressure.NORMAL,
+        )
+
+    async def shutdown(self) -> DrainResult:
+        return DrainResult(completed=0, force_cancelled=0, drain_duration_seconds=0.0)
+
+
+def _make_budget() -> ResidencyBudget:
+    return ResidencyBudget(
+        wired_limit_bytes=64_000_000_000,
+        usable_budget_bytes=56_000_000_000,
+        weight_bytes=1_000_000,
+        activation_scratch_bytes=1_000_000,
+        kv_budget_bytes=10_000_000_000,
+        prefix_cache_budget_bytes=8_000_000_000,
+    )
+
+
+@pytest.fixture
+def sdk_client():
+    app = FastAPI(title="mlxz-sdk-test")
+    app.include_router(health_router)
+    app.include_router(openai_router)
+
+    config = RuntimeConfig(model="mock-model")
+    app.state.engine = _MockEngine()
+    app.state.admission = AdmissionController(_make_budget(), config, n_layers=2, n_heads=2, head_dim=64)
+    app.state.tokenizer = _MockTokenizer()
+    app.state.cancellations = CancellationRegistry()
+    app.state.telemetry = None
+    app.state.telemetry_run_id = None
+
+    transport = ASGITransport(app=app)
+    http_client = httpx.Client(transport=transport, base_url="http://test")
+    client = OpenAI(base_url="http://test/v1", api_key="test", http_client=http_client)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+def test_chat_non_streaming(sdk_client) -> None:
+    resp = sdk_client.chat.completions.create(
+        model="mock-model",
+        messages=[{"role": "user", "content": "Say hi"}],
+        max_tokens=3,
+    )
+    assert resp.choices[0].message.content == "Hello SDK"
+    assert resp.usage.completion_tokens > 0
+
+
+def test_chat_streaming(sdk_client) -> None:
+    stream = sdk_client.chat.completions.create(
+        model="mock-model",
+        messages=[{"role": "user", "content": "Say hi"}],
+        max_tokens=3,
+        stream=True,
+    )
+    parts: list[str] = []
+    for chunk in stream:
+        content = chunk.choices[0].delta.content or ""
+        if content:
+            parts.append(content)
+    assert "".join(parts) == "Hello SDK"
+
+
+def test_completions_non_streaming(sdk_client) -> None:
+    resp = sdk_client.completions.create(
+        model="mock-model",
+        prompt="Hello",
+        max_tokens=3,
+    )
+    assert resp.choices[0].text == "Hello SDK"
+
+
+def test_list_models(sdk_client) -> None:
+    models = sdk_client.models.list()
+    assert models.data[0].id == "mock-model"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -80,6 +80,7 @@ class TestPrefixCacheConfigDefaults:
         assert pc.disk_budget_gb == 50.0
         assert pc.disk_path == Path.home() / ".cache/mlxz/prefix"
         assert pc.disk_tier_enabled is True
+        assert pc.block_size == 8
 
 
 class TestSpeculativeConfigDefaults:
@@ -236,6 +237,14 @@ class TestPrefixCacheConfigValidation:
     def test_disk_budget_negative_rejected(self):
         with pytest.raises(ValidationError, match="disk_budget_gb"):
             PrefixCacheConfig(disk_budget_gb=-1.0)
+
+    def test_block_size_zero_rejected(self):
+        with pytest.raises(ValidationError, match="block_size"):
+            PrefixCacheConfig(block_size=0)
+
+    def test_block_size_over_max_rejected(self):
+        with pytest.raises(ValidationError, match="block_size"):
+            PrefixCacheConfig(block_size=300)
 
 
 class TestRequestLimitsValidation:

--- a/tests/unit/test_prefix_memory.py
+++ b/tests/unit/test_prefix_memory.py
@@ -15,6 +15,13 @@ def _make_mock_kv_cache(n_layers: int = 2, seq_len: int = 4, head_dim: int = 8):
         @property
         def state(self):
             return (self._keys, self._values)
+        def is_trimmable(self):
+            return True
+        def trim(self, num_tokens):
+            if num_tokens <= 0:
+                return
+            self._keys = self._keys[:, :, :-num_tokens, :]
+            self._values = self._values[:, :, :-num_tokens, :]
     return [MockKVCache(seq_len, head_dim) for _ in range(n_layers)]
 
 
@@ -53,6 +60,18 @@ class TestPrefixCacheMemory:
 
         n_matched, kv_states = cache.lookup_sync(long_hashes)
         assert n_matched > 0  # found the 2-chunk prefix
+        assert kv_states is not None
+
+    def test_shared_prefix_boundary_is_cached(self):
+        """Long prompts should cache intermediate chunk-boundary prefixes."""
+        cache = PrefixCacheMemory(memory_budget_bytes=10_000_000)
+        full_hashes = _make_hashes(4)
+        kv = _make_mock_kv_cache(seq_len=8)
+        cache.store_sync(full_hashes, kv, block_size=2)
+
+        prefix_hashes = full_hashes[:2]
+        n_matched, kv_states = cache.lookup_sync(prefix_hashes)
+        assert n_matched == 4
         assert kv_states is not None
 
     def test_lru_eviction(self):

--- a/tests/unit/test_sampling.py
+++ b/tests/unit/test_sampling.py
@@ -24,6 +24,12 @@ class TestGreedySampling:
         assert logprob is not None
         assert logprob < 0  # log probabilities are negative
 
+    def test_greedy_can_skip_logprob(self):
+        logits = mx.array([1.0, 5.0, 3.0])
+        params = SamplingParams(temperature=0.0, return_logprob=False)
+        _, logprob = sample(logits, params)
+        assert logprob is None
+
 
 @pytest.mark.metal
 class TestTopK:
@@ -88,3 +94,11 @@ class TestDeterminism:
             t, _ = sample(logits, params, key=key)
             results.add(t)
         assert len(results) > 1  # at least 2 different tokens
+
+
+class TestNoLogprob:
+    def test_sampling_can_skip_logprob(self):
+        logits = mx.array([1.0, 2.0, 3.0, 4.0])
+        params = SamplingParams(temperature=1.0, return_logprob=False)
+        _, logprob = sample(logits, params, key=mx.random.key(0))
+        assert logprob is None


### PR DESCRIPTION
## What changed
- Wired and validated the engine/config/docs cleanup from the earlier sprint.
- Added decode profiling and canonical agent-workload benchmarks.
- Documented the benchmark methodology and the thesis in `docs/whitepaper.md` and `docs/experiments.md`.
- Implemented an exact-offset batched decode path in `ContinuousBatchingEngine`.

## Why
The goal of this branch was to push beyond Python micro-optimizations and find a path that actually improves throughput or concurrency on MLX. Profiling showed decode time was dominated by cache mutation and attention, so the next useful step was to test batching compatible requests before moving to an MLX-side primitive.

## Impact
- Isolated single-request throughput remains roughly parity with `mlx-lm`.
- Concurrent agent-style workload improved materially after exact-offset batching.
- The repo now has a reproducible benchmark and profiling trail for the next optimization pass.

## Validation
- `uv run pytest tests/unit/test_request.py tests/unit/test_sampling.py tests/unit/test_prefix_memory.py -q`
- `uv run python -m compileall src/mlxz/engine/continuous.py`
- `uv run python benchmarks/run_benchmark.py --model mlx-community/Llama-3.1-8B-Instruct-4bit --mlxz-url http://127.0.0.1:8321 --prompt-tokens 64 --max-tokens 128 --runs 3 --no-fail-on-regression`
- `uv run python benchmarks/agent_workload.py --mlxz-url http://127.0.0.1:8321 --requests 8 --max-tokens 128`

## Notes
The remaining throughput ceiling appears to be inside MLX cache mutation / attention, not tokenizer or sampler overhead. If we want the next step to be a wider win, the follow-up should be an MLX-side primitive or a looser batching compatibility rule.