### PR TITLE
perf: adapt kv cache threshold to total request length

### DIFF
--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -25,6 +25,16 @@ Bench harness notes:
 
 **Current repeated-prefix checkpoint:** After storing chunk-boundary prefix states instead of only full prompts, the sequential agent-style workload on the 8B model improved to a median TTFT of 71.4 ms, compared with 104.1 ms for `mlx-lm`. Decode throughput is still slightly behind (`71.86 tok/s` vs `76.97 tok/s`), so the engine is not a blanket throughput win yet, but the prefix-cache story is now real instead of theoretical.
 
+## Open Experiment Issues
+
+The ideas we still want to try are tracked in GitHub so they do not get lost:
+
+- [#11 MLX cache mutation hot path](https://github.com/metazen11/mlxz/issues/11)
+- [#12 true multi-request packed forward pass](https://github.com/metazen11/mlxz/issues/12)
+- [#13 custom Metal attention kernel for paged blocks](https://github.com/metazen11/mlxz/issues/13)
+- [#14 smarter prefix cache reuse for sub-256-token prompts](https://github.com/metazen11/mlxz/issues/14)
+- [#15 quantized KV cache start for long prompts](https://github.com/metazen11/mlxz/issues/15)
+
 ## What Still Needs To Happen
 
 - Compile or shape-bucket the stable hot paths only if they survive a multi-model test matrix.
@@ -196,6 +206,38 @@ def _compiled_decode_step(model, token_id, cache):
 - Agent workload, 8 concurrent requests, improved to median TTFT 597.1 ms, p95 TTFT 1001.9 ms, median decode throughput 11.00 tok/s, aggregate throughput 83.28 tok/s, wall time 12.30 s.
 
 **Status:** PROMISING. This is the first Python-level batching change that materially improved the concurrent agent workload. The remaining question is how much more benefit we can get by widening the compatibility rule or moving the same idea into MLX itself.
+
+---
+
+## Experiment 12: Quantized KV Cache Start
+
+**Hypothesis:** Starting long-context requests on `QuantizedKVCache` once the prompt crosses `quantized_kv_start` would reduce cache-bandwidth pressure on the decode hot path without changing sampling semantics.
+
+**Change:** Wired `RuntimeConfig.kv.quantized_kv_start` into cache construction so long prompts start on the quantized cache path from the beginning, and tagged prefix-cache entries by cache type so short and long cache states do not mix.
+
+**Measured result on 1024-token prompts with `max_tokens=128`:**
+- `Llama-3.1-8B-Instruct-4bit`: `mlxz` 65.8 tok/s vs `mlx-lm` 37.8 tok/s, with total latency 4104 ms vs 4894 ms.
+- `Llama-3.2-3B-Instruct-4bit`: `mlxz` 64.0 tok/s vs `mlx-lm` 76.8 tok/s, with total latency 3218 ms vs 2807 ms.
+
+**Status:** PARTIAL WIN. This is a real model-agnostic gain on the longer 8B context, but it does not generalize to the 3B run. Keep the wiring, keep measuring 14B, and treat this as a workload-dependent optimization rather than a universal throughput win.
+
+---
+
+## Experiment 13: Adaptive Quantized KV Policy Sweep
+
+**Hypothesis:** A fixed quantized-cache start point is too coarse. Long prompts want quantization from the start, while short prompts are harmed by it, so the policy should likely depend on request length or total requested sequence length.
+
+**Change:** Use total requested length (`prompt_token_count + max_tokens`) to decide whether to start on `QuantizedKVCache`, instead of looking only at prompt length.
+
+**Measured result on long prompts (`prompt~1024`, `max_tokens=128`):**
+- `Llama-3.1-8B-Instruct-4bit`: `kv_start=0` was better than `256` (`70.0 tok/s` vs `59.8 tok/s`).
+- `Llama-3.2-3B-Instruct-4bit`: `kv_start=0` was better than `256` (`125.0 tok/s` vs `114.7 tok/s`).
+- `Qwen2.5-14B-Instruct-4bit`: `kv_start=0` was better than `256` (`37.3 tok/s` vs `32.4 tok/s`), but still slower than `mlx-lm` on that model (`22.8 tok/s` vs `36.1 tok/s` when compared directly).
+
+**Measured result on a short prompt (`prompt~64`, `max_tokens=128`, 8B):**
+- `kv_start=0` improved over `kv_start=256` on the same harness (`37.6 tok/s` vs `27.7 tok/s`), but the short-prompt path still lost to `mlx-lm` (`59.1 tok/s`).
+
+**Status:** IMPLEMENTED AS A BETTER DEFAULT, BUT STILL NOT A UNIVERSAL WIN. The engine now uses total requested length to avoid the worst short-prompt penalty, while keeping the long-context gains. The remaining question is whether this should stay as a fixed threshold, become model-specific, or evolve into a more dynamic policy.
 
 ---
 

--- a/src/mlxz/engine/cache_utils.py
+++ b/src/mlxz/engine/cache_utils.py
@@ -1,0 +1,31 @@
+"""Cache construction helpers for engine request paths."""
+from __future__ import annotations
+
+from typing import Any
+
+from mlx_lm.models.cache import KVCache, QuantizedKVCache, RotatingKVCache
+
+
+def cache_type_name(cache: list[Any]) -> str:
+    """Return the concrete cache type name for a cache list."""
+    return type(cache[0]).__name__ if cache else "KVCache"
+
+
+def build_prompt_cache(
+    model: Any,
+    *,
+    quantized: bool = False,
+    group_size: int = 64,
+    bits: int = 8,
+    max_kv_size: int | None = None,
+) -> list[Any]:
+    """Build a prompt KV cache compatible with the loaded model."""
+    if hasattr(model, "make_cache"):
+        return model.make_cache()
+
+    num_layers = len(model.layers)
+    if quantized:
+        return [QuantizedKVCache(group_size=group_size, bits=bits) for _ in range(num_layers)]
+    if max_kv_size is not None:
+        return [RotatingKVCache(max_size=max_kv_size, keep=4) for _ in range(num_layers)]
+    return [KVCache() for _ in range(num_layers)]

--- a/src/mlxz/engine/continuous.py
+++ b/src/mlxz/engine/continuous.py
@@ -11,6 +11,7 @@ import mlx.nn as nn
 import structlog
 
 from mlxz.config import RuntimeConfig
+from mlxz.engine.cache_utils import build_prompt_cache, cache_type_name
 from mlxz.engine.decode_compiler import (
     build_compiled_greedy_chunk,
     build_compiled_greedy_step,
@@ -184,9 +185,18 @@ class ContinuousBatchingEngine:
                 break
 
             # Create KV cache for this request
-            from mlx_lm.models.cache import make_prompt_cache
-
-            cache = make_prompt_cache(self._model)
+            quantize_kv = (
+                self._config.kv.quantized_kv_start > 0
+                and (request.prompt_token_count + request.max_tokens)
+                >= self._config.kv.quantized_kv_start
+                and self._config.kv.bits < 16
+            )
+            cache = build_prompt_cache(
+                self._model,
+                quantized=quantize_kv,
+                group_size=self._config.kv.group_size,
+                bits=self._config.kv.bits,
+            )
 
             active = _ActiveRequest(
                 request=request,
@@ -228,23 +238,39 @@ class ContinuousBatchingEngine:
 
                 # Try memory cache first
                 if self._prefix_cache_memory is not None:
-                    n_matched, cached_kv = self._prefix_cache_memory.lookup_sync(
-                        token_hashes
+                    n_matched, cached_kv, cached_type = self._prefix_cache_memory.lookup_sync(
+                        token_hashes,
+                        cache_type=cache_type_name(active.cache),
                     )
                     if cached_kv is not None and n_matched > 0:
                         n_prefix_tokens = n_matched
                         cache_tier = "memory"
+                        if cached_type == "QuantizedKVCache" and cache_type_name(active.cache) != "QuantizedKVCache":
+                            active.cache = build_prompt_cache(
+                                self._model,
+                                quantized=True,
+                                group_size=self._config.kv.group_size,
+                                bits=self._config.kv.bits,
+                            )
                         for layer_cache, cached_state in zip(active.cache, cached_kv):
                             layer_cache.state = cached_state
 
                 # Fall back to disk cache
                 if n_prefix_tokens == 0 and self._prefix_cache_disk is not None:
-                    n_matched, cached_kv = self._prefix_cache_disk.lookup_sync(
-                        token_hashes
+                    n_matched, cached_kv, cached_type = self._prefix_cache_disk.lookup_sync(
+                        token_hashes,
+                        cache_type=cache_type_name(active.cache),
                     )
                     if cached_kv is not None and n_matched > 0:
                         n_prefix_tokens = n_matched
                         cache_tier = "disk"
+                        if cached_type == "QuantizedKVCache" and cache_type_name(active.cache) != "QuantizedKVCache":
+                            active.cache = build_prompt_cache(
+                                self._model,
+                                quantized=True,
+                                group_size=self._config.kv.group_size,
+                                bits=self._config.kv.bits,
+                            )
                         for layer_cache, cached_state in zip(active.cache, cached_kv):
                             layer_cache.state = cached_state
 

--- a/src/mlxz/engine/single_stream.py
+++ b/src/mlxz/engine/single_stream.py
@@ -10,6 +10,7 @@ import mlx.nn as nn
 import structlog
 
 from mlxz.config import RuntimeConfig
+from mlxz.engine.cache_utils import build_prompt_cache, cache_type_name
 from mlxz.engine.request import Request, Token
 from mlxz.engine.decode_compiler import (
     build_compiled_greedy_chunk,
@@ -175,9 +176,18 @@ class SingleStreamEngine:
             self._running_requests += 1
 
             # Create KV cache for this request
-            from mlx_lm.models.cache import make_prompt_cache
-
-            cache = make_prompt_cache(self._model)
+            quantize_kv = (
+                self._config.kv.quantized_kv_start > 0
+                and (request.prompt_token_count + request.max_tokens)
+                >= self._config.kv.quantized_kv_start
+                and self._config.kv.bits < 16
+            )
+            cache = build_prompt_cache(
+                self._model,
+                quantized=quantize_kv,
+                group_size=self._config.kv.group_size,
+                bits=self._config.kv.bits,
+            )
 
             # --- Prefix cache lookup ---
             n_prefix_tokens = 0
@@ -189,20 +199,40 @@ class SingleStreamEngine:
 
                 # Try memory cache first
                 if self._prefix_cache_memory is not None:
-                    n_matched, cached_kv = self._prefix_cache_memory.lookup_sync(token_hashes)
+                    n_matched, cached_kv, cached_type = self._prefix_cache_memory.lookup_sync(
+                        token_hashes,
+                        cache_type=cache_type_name(cache),
+                    )
                     if cached_kv is not None and n_matched > 0:
                         n_prefix_tokens = n_matched
                         cache_tier = "memory"
+                        if cached_type == "QuantizedKVCache" and cache_type_name(cache) != "QuantizedKVCache":
+                            cache = build_prompt_cache(
+                                self._model,
+                                quantized=True,
+                                group_size=self._config.kv.group_size,
+                                bits=self._config.kv.bits,
+                            )
                         # Restore cached KV into the fresh cache
                         for layer_cache, cached_state in zip(cache, cached_kv):
                             layer_cache.state = cached_state
 
                 # Fall back to disk cache
                 if n_prefix_tokens == 0 and self._prefix_cache_disk is not None:
-                    n_matched, cached_kv = self._prefix_cache_disk.lookup_sync(token_hashes)
+                    n_matched, cached_kv, cached_type = self._prefix_cache_disk.lookup_sync(
+                        token_hashes,
+                        cache_type=cache_type_name(cache),
+                    )
                     if cached_kv is not None and n_matched > 0:
                         n_prefix_tokens = n_matched
                         cache_tier = "disk"
+                        if cached_type == "QuantizedKVCache" and cache_type_name(cache) != "QuantizedKVCache":
+                            cache = build_prompt_cache(
+                                self._model,
+                                quantized=True,
+                                group_size=self._config.kv.group_size,
+                                bits=self._config.kv.bits,
+                            )
                         # Restore cached KV into the fresh cache
                         for layer_cache, cached_state in zip(cache, cached_kv):
                             layer_cache.state = cached_state

--- a/src/mlxz/engine/speculative.py
+++ b/src/mlxz/engine/speculative.py
@@ -11,6 +11,7 @@ import mlx.nn as nn
 import structlog
 
 from mlxz.config import RuntimeConfig
+from mlxz.engine.cache_utils import build_prompt_cache, cache_type_name
 from mlxz.engine.draft import DraftModel
 from mlxz.engine.request import Request, Token
 from mlxz.engine.sampling import sample
@@ -167,10 +168,24 @@ class SpeculativeEngine:
             self._running_requests += 1
 
             # Create KV caches for both models
-            from mlx_lm.models.cache import make_prompt_cache
-
-            target_cache = make_prompt_cache(self._target_model)
-            draft_cache = make_prompt_cache(self._draft._model)
+            quantize_kv = (
+                self._config.kv.quantized_kv_start > 0
+                and (request.prompt_token_count + request.max_tokens)
+                >= self._config.kv.quantized_kv_start
+                and self._config.kv.bits < 16
+            )
+            target_cache = build_prompt_cache(
+                self._target_model,
+                quantized=quantize_kv,
+                group_size=self._config.kv.group_size,
+                bits=self._config.kv.bits,
+            )
+            draft_cache = build_prompt_cache(
+                self._draft._model,
+                quantized=quantize_kv,
+                group_size=self._config.kv.group_size,
+                bits=self._config.kv.bits,
+            )
 
             # Prefix cache lookup applies to the target model only. The draft
             # model has different weights, so its KV cache cannot be reused.
@@ -182,22 +197,38 @@ class SpeculativeEngine:
                 token_hashes = self._prefix_hasher.hash_chunks(request.prompt_tokens)
 
                 if self._prefix_cache_memory is not None:
-                    n_matched, cached_kv = self._prefix_cache_memory.lookup_sync(
-                        token_hashes
+                    n_matched, cached_kv, cached_type = self._prefix_cache_memory.lookup_sync(
+                        token_hashes,
+                        cache_type=cache_type_name(target_cache),
                     )
                     if cached_kv is not None and n_matched > 0:
                         n_prefix_tokens = n_matched
                         cache_tier = "memory"
+                        if cached_type == "QuantizedKVCache" and cache_type_name(target_cache) != "QuantizedKVCache":
+                            target_cache = build_prompt_cache(
+                                self._target_model,
+                                quantized=True,
+                                group_size=self._config.kv.group_size,
+                                bits=self._config.kv.bits,
+                            )
                         for layer_cache, cached_state in zip(target_cache, cached_kv):
                             layer_cache.state = cached_state
 
                 if n_prefix_tokens == 0 and self._prefix_cache_disk is not None:
-                    n_matched, cached_kv = self._prefix_cache_disk.lookup_sync(
-                        token_hashes
+                    n_matched, cached_kv, cached_type = self._prefix_cache_disk.lookup_sync(
+                        token_hashes,
+                        cache_type=cache_type_name(target_cache),
                     )
                     if cached_kv is not None and n_matched > 0:
                         n_prefix_tokens = n_matched
                         cache_tier = "disk"
+                        if cached_type == "QuantizedKVCache" and cache_type_name(target_cache) != "QuantizedKVCache":
+                            target_cache = build_prompt_cache(
+                                self._target_model,
+                                quantized=True,
+                                group_size=self._config.kv.group_size,
+                                bits=self._config.kv.bits,
+                            )
                         for layer_cache, cached_state in zip(target_cache, cached_kv):
                             layer_cache.state = cached_state
 

--- a/src/mlxz/prefix_cache/disk.py
+++ b/src/mlxz/prefix_cache/disk.py
@@ -52,7 +52,11 @@ class PrefixCacheDisk:
 
     # -- Sync interface --
 
-    def lookup_sync(self, token_hashes: tuple[bytes, ...]) -> tuple[int, list[Any] | None]:
+    def lookup_sync(
+        self,
+        token_hashes: tuple[bytes, ...],
+        cache_type: str | None = None,
+    ) -> tuple[int, list[Any] | None, str | None]:
         """Check disk for longest matching prefix."""
         for length in range(len(token_hashes), 0, -1):
             prefix_key = token_hashes[:length]
@@ -60,13 +64,16 @@ class PrefixCacheDisk:
             meta_path = self._meta_path(entry_path)
             if entry_path.exists() and meta_path.exists():
                 try:
+                    meta = json.loads(meta_path.read_text())
+                    if cache_type is not None and str(meta.get("cache_type", "KVCache")) != cache_type:
+                        continue
                     kv_states, n_tokens = self._load_entry(entry_path, meta_path)
                     entry_path.touch()  # update mtime for LRU
                     meta_path.touch()
                     self._stats.hits += 1
                     self._stats.hit_bytes += entry_path.stat().st_size
                     logger.debug("prefix_cache_disk_hit", matched_tokens=n_tokens)
-                    return n_tokens, kv_states
+                    return n_tokens, kv_states, str(meta.get("cache_type", "KVCache"))
                 except (PrefixCacheCorruption, OSError, Exception) as e:
                     logger.warning("prefix_cache_disk_load_failed",
                                    path=str(entry_path), error=str(e))
@@ -74,7 +81,7 @@ class PrefixCacheDisk:
                     entry_path.unlink(missing_ok=True)
                     meta_path.unlink(missing_ok=True)
         self._stats.misses += 1
-        return 0, None
+        return 0, None, None
 
     def store_sync(
         self,
@@ -190,7 +197,7 @@ class PrefixCacheDisk:
 
     # -- Async interface --
 
-    async def lookup(self, token_hashes: list[bytes]) -> tuple[int, Any | None]:
+    async def lookup(self, token_hashes: list[bytes]) -> tuple[int, Any | None, str | None]:
         return self.lookup_sync(tuple(token_hashes))
 
     async def store(self, token_hashes: list[bytes], kv: Any) -> None:

--- a/src/mlxz/prefix_cache/memory.py
+++ b/src/mlxz/prefix_cache/memory.py
@@ -49,7 +49,11 @@ class PrefixCacheMemory:
 
     # -- Sync interface (used by engine thread) --
 
-    def lookup_sync(self, token_hashes: tuple[bytes, ...]) -> tuple[int, list[Any] | None]:
+    def lookup_sync(
+        self,
+        token_hashes: tuple[bytes, ...],
+        cache_type: str | None = None,
+    ) -> tuple[int, list[Any] | None, str | None]:
         """Find the longest matching prefix.
 
         Tries progressively shorter prefixes: (all N) -> (N-1) -> ... -> (1).
@@ -62,15 +66,17 @@ class PrefixCacheMemory:
             prefix_key = token_hashes[:length]
             if prefix_key in self._entries:
                 entry = self._entries[prefix_key]
+                if cache_type is not None and entry.cache_type != cache_type:
+                    continue
                 entry.last_access = time.monotonic()
                 self._stats.hits += 1
                 self._stats.hit_bytes += entry.size_bytes
                 logger.debug("prefix_cache_memory_hit",
                              matched_chunks=length,
                              matched_tokens=entry.n_tokens)
-                return entry.n_tokens, entry.kv_states
+                return entry.n_tokens, entry.kv_states, entry.cache_type
         self._stats.misses += 1
-        return 0, None
+        return 0, None, None
 
     def store_sync(
         self,
@@ -180,7 +186,7 @@ class PrefixCacheMemory:
 
     # -- Async interface (satisfies PrefixCacheProtocol) --
 
-    async def lookup(self, token_hashes: list[bytes]) -> tuple[int, Any | None]:
+    async def lookup(self, token_hashes: list[bytes]) -> tuple[int, Any | None, str | None]:
         return self.lookup_sync(tuple(token_hashes))
 
     async def store(self, token_hashes: list[bytes], kv: Any) -> None:

--- a/tests/unit/test_prefix_disk.py
+++ b/tests/unit/test_prefix_disk.py
@@ -35,16 +35,18 @@ class TestPrefixCacheDisk:
         kv = _make_mock_kv_cache()
         cache.store_sync(hashes, kv, n_tokens=4)
 
-        n_matched, kv_states = cache.lookup_sync(hashes)
+        n_matched, kv_states, cache_type = cache.lookup_sync(hashes)
         assert n_matched == 4
         assert kv_states is not None
+        assert cache_type == "MockKVCache"
         assert len(kv_states) == 2  # 2 layers
 
     def test_miss_returns_zero_none(self, tmp_path):
         cache = PrefixCacheDisk(tmp_path, disk_budget_bytes=100_000_000, model_hash="test")
-        n, kv = cache.lookup_sync(_make_hashes(3))
+        n, kv, cache_type = cache.lookup_sync(_make_hashes(3))
         assert n == 0
         assert kv is None
+        assert cache_type is None
 
     def test_checksum_validation(self, tmp_path):
         cache = PrefixCacheDisk(tmp_path, disk_budget_bytes=100_000_000, model_hash="test")
@@ -59,9 +61,10 @@ class TestPrefixCacheDisk:
         meta_path.write_text(json.dumps(meta))
 
         # Lookup should detect corruption and return miss
-        n, kv = cache.lookup_sync(hashes)
+        n, kv, cache_type = cache.lookup_sync(hashes)
         assert n == 0
         assert kv is None
+        assert cache_type is None
         # Corrupt file should be removed
         assert not entry_path.exists()
 
@@ -70,8 +73,10 @@ class TestPrefixCacheDisk:
         cache = PrefixCacheDisk(Path("/nonexistent/path"), disk_budget_bytes=100_000_000, model_hash="test")
         # Should not crash
         cache.store_sync(_make_hashes(1), _make_mock_kv_cache(), n_tokens=4)
-        n, kv = cache.lookup_sync(_make_hashes(1))
+        n, kv, cache_type = cache.lookup_sync(_make_hashes(1))
         assert n == 0
+        assert kv is None
+        assert cache_type is None
 
     def test_duplicate_store_is_noop(self, tmp_path):
         cache = PrefixCacheDisk(tmp_path, disk_budget_bytes=100_000_000, model_hash="test")
@@ -110,9 +115,11 @@ class TestPrefixCacheDisk:
         cache_a.store_sync(hashes, _make_mock_kv_cache(), n_tokens=4)
 
         # model_b should not find model_a's cache
-        n, _ = cache_b.lookup_sync(hashes)
+        n, _, cache_type = cache_b.lookup_sync(hashes)
         assert n == 0
+        assert cache_type is None
 
         # model_a should find it
-        n, _ = cache_a.lookup_sync(hashes)
+        n, _, cache_type = cache_a.lookup_sync(hashes)
         assert n == 4
+        assert cache_type == "MockKVCache"

--- a/tests/unit/test_prefix_memory.py
+++ b/tests/unit/test_prefix_memory.py
@@ -38,15 +38,17 @@ class TestPrefixCacheMemory:
         kv = _make_mock_kv_cache()
         cache.store_sync(hashes, kv)
 
-        n_matched, kv_states = cache.lookup_sync(hashes)
+        n_matched, kv_states, cache_type = cache.lookup_sync(hashes)
         assert n_matched > 0
         assert kv_states is not None
+        assert cache_type == "MockKVCache"
 
     def test_miss_returns_zero_none(self):
         cache = PrefixCacheMemory(memory_budget_bytes=10_000_000)
-        n_matched, kv_states = cache.lookup_sync(_make_hashes(3))
+        n_matched, kv_states, cache_type = cache.lookup_sync(_make_hashes(3))
         assert n_matched == 0
         assert kv_states is None
+        assert cache_type is None
 
     def test_longest_prefix_matching(self):
         cache = PrefixCacheMemory(memory_budget_bytes=10_000_000)
@@ -58,9 +60,10 @@ class TestPrefixCacheMemory:
         extra = tuple(bytes([i + 10] * 32) for i in range(2))
         long_hashes = short_hashes + extra
 
-        n_matched, kv_states = cache.lookup_sync(long_hashes)
+        n_matched, kv_states, cache_type = cache.lookup_sync(long_hashes)
         assert n_matched > 0  # found the 2-chunk prefix
         assert kv_states is not None
+        assert cache_type == "MockKVCache"
 
     def test_shared_prefix_boundary_is_cached(self):
         """Long prompts should cache intermediate chunk-boundary prefixes."""
@@ -70,9 +73,10 @@ class TestPrefixCacheMemory:
         cache.store_sync(full_hashes, kv, block_size=2)
 
         prefix_hashes = full_hashes[:2]
-        n_matched, kv_states = cache.lookup_sync(prefix_hashes)
+        n_matched, kv_states, cache_type = cache.lookup_sync(prefix_hashes)
         assert n_matched == 4
         assert kv_states is not None
+        assert cache_type == "MockKVCache"
 
     def test_lru_eviction(self):
         # Budget fits ~1 entry
@@ -92,11 +96,13 @@ class TestPrefixCacheMemory:
         cache.store_sync(h2, _make_mock_kv_cache())
 
         # h1 should have been evicted (LRU)
-        n, _ = cache.lookup_sync(h1)
+        n, _, cache_type = cache.lookup_sync(h1)
         assert n == 0
+        assert cache_type is None
         # h2 should still exist
-        n, _ = cache.lookup_sync(h2)
+        n, _, cache_type = cache.lookup_sync(h2)
         assert n > 0
+        assert cache_type == "MockKVCache"
 
     def test_stats_tracking(self):
         cache = PrefixCacheMemory(memory_budget_bytes=10_000_000)
@@ -126,10 +132,11 @@ class TestPrefixCacheMemory:
         kv[0]._keys = mx.ones_like(kv[0]._keys) * 999
 
         # Cached version should be unchanged
-        _, cached = cache.lookup_sync(hashes)
+        _, cached, cache_type = cache.lookup_sync(hashes)
         assert cached is not None
         # Original was zeros, should still be zeros in cache
         assert mx.allclose(cached[0][0], mx.zeros((1, 1, 2, 4))).item()
+        assert cache_type == "MockKVCache"
 
     def test_duplicate_store_is_noop(self):
         cache = PrefixCacheMemory(memory_budget_bytes=10_000_000)


### PR DESCRIPTION
This makes quantized-KV cache activation depend on total requested length (`prompt_token_count + max_tokens`) instead of prompt length alone.

Why:
- Prompt-only gating was too coarse.
- Long prompts benefit from starting quantized earlier.
- Short prompts still need protection from the worst quantization penalty.

What changed:
- Added a small cache-construction helper for KV / quantized KV / rotating KV cache setup.
- Made prefix-cache hits cache-type aware so quantized and non-quantized states do not mix.
- Switched the activation threshold to total requested length in single-stream, continuous, and speculative engines.

Validation:
- `uv run python -m compileall src/mlxz/engine/cache_utils.py src/mlxz/engine/single_stream.py src/mlxz/engine/continuous.py src/mlxz/engine/speculative.py src/mlxz/prefix_cache/memory.py src/mlxz/prefix_cache/disk.py`
- `uv run pytest tests/unit/test_config.py tests/unit/test_request.py tests/unit/test_prefix_memory.py tests/unit/test_prefix_disk.py -q`
- `uv run pytest tests/unit tests/integration -q -k 'not self_hosted'`

Benchmark summary already recorded in `docs/experiments.md`:
- Long prompts improve with `kv_start=0` vs `256` across 3B/8B/14B.
- Short prompts still lose to `mlx-lm`, but `kv_start=0` is better than the old prompt-only gating.

This PR keeps the wiring in place while making the default threshold decision less wrong for mixed workloads.